### PR TITLE
Comparator library for AVR DA and AVR DB

### DIFF
--- a/megaavr/libraries/Comparator/README.md
+++ b/megaavr/libraries/Comparator/README.md
@@ -1,22 +1,21 @@
 # Comparator
-A library for interfacing with the analog comparator peripheral in the megaAVR-0 series MCUs.  
+A library for interfacing with the analog comparator peripheral in the AVR DA and DB series MCUs.  
 Developed by [MCUdude](https://github.com/MCUdude/).  
-The megaAVR-0 has one comparator where four positive and three negative pins are available for use. An alternative for the negative pin is to use an internally generated reference voltage instead.
-More useful information about the analog comparator can be found in the [Microchip Application Note TB3211](http://ww1.microchip.com/downloads/en/AppNotes/TB3211-Getting-Started-with-AC-90003211A.pdf) and in the [megaAVR-0 family data sheet](http://ww1.microchip.com/downloads/en/DeviceDoc/megaAVR0-series-Family-Data-Sheet-DS40002015B.pdf).
+The AVR DA/DB has three comparators where four positive and three negative pins are available for use. An alternative for the negative pin is to use an internally generated reference voltage instead.
 
 
 ## Comparator
-Class for interfacing with the built-in comparator. use the predefined objects `Comparator` or `Comparator0`.
+Class for interfacing with the built-in comparator. use the predefined objects `Comparator`, `Comparator1` or `Comparator2`.
 
 
 ### input_p
 Variable for setting what input pin the positive input of the comparator should be connected to 
 Accepted values:
 ``` c++
-in_p::in0; // Use positive input pin 0 (PD2) as input
-in_p::in1; // Use positive input pin 1 (PD4) as input
-in_p::in2; // Use positive input pin 2 (PD6) as input
-in_p::in3; // Use positive input pin 3 (PD1) as input
+in_p::in0; // Use positive input pin 0 as input
+in_p::in1; // Use positive input pin 1 as input
+in_p::in2; // Use positive input pin 2 as input
+in_p::in3; // Use positive input pin 3 as input
 ```
 
 ##### Usage
@@ -32,9 +31,9 @@ Comparator.input_p = in_p::in0;  // Connect positive input pin 0 to the positive
 Variable for setting what input pin the negative input of the comparator should be connected to 
 Accepted values:
 ``` c++
-in_n::in0;    // Use positive input pin 0 (PD3) as input
-in_n::in1;    // Use positive input pin 1 (PD5) as input
-in_n::in2;    // Use positive input pin 2 (PD7) as input
+in_n::in0;    // Use positive input pin 0 as input
+in_n::in1;    // Use positive input pin 1 as input
+in_n::in2;    // Use positive input pin 2 as input
 in_p::dacref; // Use DACREF as input
 ```
 
@@ -51,18 +50,19 @@ Comparator.input_n = in_n::in0;  // Connect negative input pin 0 to the negative
 Variable for setting what reference voltage the DACREF should use. This voltage is internally generated. 
 Accepted values:
 ``` c++
-ref::disable;   // Do not use any reference
-ref::vref_0v55; // 0.55V internal voltage
-ref::vref_1v1;  // 1.1V internal voltage
-ref::vref_1v5;  // 1.5V internal voltage
-ref::vref_2v5;  // 2.5V internal voltage
-ref::vref_4v3;  // 4.3V internal voltage
-ref::vref_avcc; // Use voltage on AVCC pin
+ref::disable;    // Do not use any reference
+ref::vref_1v024; // 1.024V internal voltage
+ref::vref_2v048; // 2.048V internal voltage
+ref::vref_2v500; // 2.5V internal voltage
+ref::vref_2v5;
+ref::vref_4v096; // 4.096V internal voltage
+ref::vref_vdd;   // VDD as reference
+ref::vref_vrefa; // External reference from the VREFA pin
 ```
 
 ##### Usage
 ``` c++
-Comparator.reference = ref::vref_2v5;  // Use the internal 2.5V reference for the DACREF
+Comparator.reference = ref::vref_4v096;  // Use the internal 4.096V reference for the DACREF
 ```
 
 ##### Default state
@@ -119,6 +119,23 @@ Comparator.output = out::enable; // Enable output pin (PA7)
 
 ##### Default state
 `Comparator.output` defaults to `out::disable` if not specified in the user program.
+
+
+### output_swap
+Variable for pin swapping the physical output pin to its alternative position. See the pinout diagrams in the DxCore README for detailed info.  
+Accepted values:
+```c++
+out::no_swap;  // Use default pin position
+out::pin_swap; // Use alternative position
+```
+
+##### Usage
+```c++
+Comparator.output_swap = out::no_swap; // No pin swap for output
+```
+
+##### Default state
+`Comparator.output_swap` defaults to `out::no_swap` if not specified in the user program.
 
 
 ## init()

--- a/megaavr/libraries/Comparator/README.md
+++ b/megaavr/libraries/Comparator/README.md
@@ -73,7 +73,7 @@ Comparator.reference = ref::vref_4v096;  // Use the internal 4.096V reference fo
 Variable for setting the DACREF value. The DACREF voltage is the voltage that the comparator uses as it's reference.  
 This is the formula for the DACREF output voltage:  
   
-<img src="http://latex.codecogs.com/svg.latex?V_{DACREF} = \frac{Comparator.dacref}{256} + Comparator.reference" border="0"/>
+<img src="http://latex.codecogs.com/svg.latex?V_{DACREF} = \frac{Comparator.dacref}{256} * Comparator.reference" border="0"/>
 
 ##### Usage
 ``` c++

--- a/megaavr/libraries/Comparator/README.md
+++ b/megaavr/libraries/Comparator/README.md
@@ -138,6 +138,23 @@ Comparator.output_swap = out::no_swap; // No pin swap for output
 `Comparator.output_swap` defaults to `out::no_swap` if not specified in the user program.
 
 
+### output_initval
+Initial state the comparator output pin has when initialized.
+Accepted values:
+```c++
+out::init_low;  // Output pin low after initialization
+out::init_high; // Output pin high after initialization
+```
+
+##### Usage
+```c++
+Comparator.output_initval = out::init_high;
+```
+
+##### Default state
+`Comparator.output_initval` defaults to `out::init_low` if not specified in the user program.
+
+
 ## init()
 Method for initializing the comparator.
 

--- a/megaavr/libraries/Comparator/examples/Hysteresis/Hysteresis.ino
+++ b/megaavr/libraries/Comparator/examples/Hysteresis/Hysteresis.ino
@@ -1,9 +1,9 @@
 /***********************************************************************|
-| megaAVR analog comparator library                                     |
+| AVR DA/DB analog comparator library                                   |
 |                                                                       |
 | Hysteresis.ino                                                        |
 |                                                                       |
-| A library for interfacing with the megaAVR analog comparator.         |
+| A library for interfacing with the AVR DA/DB analog comparator.       |
 | Developed in 2019 by MCUdude                                          |
 | https://github.com/MCUdude/                                           |
 |                                                                       |
@@ -11,8 +11,6 @@
 | comparator. The output goes high if the positive input is higher than |
 | the negative input, and low otherwise. We'll also use the built-in    |
 | hysteresis functionality to prevent false spikes.                     |
-|                                                                       |
-| See Microchip's application note TB3211 for more information.         |
 |***********************************************************************/
 
 #include <Comparator.h>

--- a/megaavr/libraries/Comparator/examples/Internal_reference/Internal_reference.ino
+++ b/megaavr/libraries/Comparator/examples/Internal_reference/Internal_reference.ino
@@ -1,9 +1,9 @@
 /***********************************************************************|
-| megaAVR analog comparator library                                     |
+| AVR DA/DB analog comparator library                                   |
 |                                                                       |
 | Internal_reference.ino                                                |
 |                                                                       |
-| A library for interfacing with the megaAVR analog comparator.         |
+| A library for interfacing with the AVR DA/DB analog comparator.       |
 | Developed in 2019 by MCUdude                                          |
 | https://github.com/MCUdude/                                           |
 |                                                                       |
@@ -14,8 +14,6 @@
 |                                                                       |
 | This is the formula for the generated voltage:                        |
 | Vdacref = (DACREF / 256) * Vref                                       |
-|                                                                       |
-| See Microchip's application note TB3211 for more information.         |
 |***********************************************************************/
 
 #include <Comparator.h>

--- a/megaavr/libraries/Comparator/examples/Interrupt/Interrupt.ino
+++ b/megaavr/libraries/Comparator/examples/Interrupt/Interrupt.ino
@@ -1,9 +1,9 @@
 /***********************************************************************|
-| megaAVR analog comparator library                                     |
+| AVR DA/DB analog comparator library                                   |
 |                                                                       |
 | Interrupt.ino                                                         |
 |                                                                       |
-| A library for interfacing with the megaAVR analog comparator.         |
+| A library for interfacing with the AVR DA/DB analog comparator.       |
 | Developed in 2019 by MCUdude                                          |
 | https://github.com/MCUdude/                                           |
 |                                                                       |
@@ -16,8 +16,6 @@
 |                                                                       |
 | This is the formula for the generated voltage:                        |
 | Vdacref = (DACREF / 256) * Vref                                       |
-|                                                                       |
-| See Microchip's application note TB3211 for more information.         |
 |***********************************************************************/
 
 #include <Comparator.h>

--- a/megaavr/libraries/Comparator/examples/Simple_comparator/Simple_comparator.ino
+++ b/megaavr/libraries/Comparator/examples/Simple_comparator/Simple_comparator.ino
@@ -1,17 +1,15 @@
 /***********************************************************************|
-| megaAVR analog comparator library                                     |
+| AVR DA/DB analog comparator library                                   |
 |                                                                       |
 | Simple_comparator.ino                                                 |
 |                                                                       |
-| A library for interfacing with the megaAVR analog comparator.         |
+| A library for interfacing with the AVR DA/DB analog comparator.       |
 | Developed in 2019 by MCUdude                                          |
 | https://github.com/MCUdude/                                           |
 |                                                                       |
 | In this example we use the negative and positive input 0 of the       |
 | comparator. The output goes high if the positive input is higher than |
 | the negative input, and low otherwise.                                |
-|                                                                       |
-| See Microchip's application note TB3211 for more information.         |
 |***********************************************************************/
 
 #include <Comparator.h>

--- a/megaavr/libraries/Comparator/src/Comparator.cpp
+++ b/megaavr/libraries/Comparator/src/Comparator.cpp
@@ -73,7 +73,7 @@ void AnalogComparator::init()
     IN1_N = PORT_ISC_INPUT_DISABLE_gc;
   else if(input_n == in_n::in2)
     IN2_N = PORT_ISC_INPUT_DISABLE_gc;
-  AC.MUXCTRL = (AC.MUXCTRL & ~0x3f) | (input_p << 3) | input_n;
+  AC.MUXCTRL = output_initval | (AC.MUXCTRL & ~0x3f) | (input_p << 3) | input_n;
 
   // Prepare for output pin swap
   PORT_t& output_port = PORTA;

--- a/megaavr/libraries/Comparator/src/Comparator.cpp
+++ b/megaavr/libraries/Comparator/src/Comparator.cpp
@@ -12,11 +12,11 @@ AnalogComparator Comparator2(2, AC2, PORTD.PIN2CTRL, PORTD.PIN4CTRL, PORTE.PIN1C
 #endif
 
 // Array for storing ISR function pointers
-#if defined(AC3_AC_vect)
+#if defined(AC2_AC_vect)
 static volatile voidFuncPtr intFuncAC[3];
-#elif defined(AC2_AC_vect)
-static volatile voidFuncPtr intFuncAC[2];
 #elif defined(AC1_AC_vect)
+static volatile voidFuncPtr intFuncAC[2];
+#elif defined(AC0_AC_vect)
 static volatile voidFuncPtr intFuncAC[1];
 #else
 #error target does not have an analog comparator!

--- a/megaavr/libraries/Comparator/src/Comparator.cpp
+++ b/megaavr/libraries/Comparator/src/Comparator.cpp
@@ -82,6 +82,7 @@ void AnalogComparator::init()
   {
     output_port = PORTC;
     pin_number = PIN6_bm;
+    PORTMUX.ACROUTEA = ~(1 << comparator_number) | output_swap;
   }
 
   // Set output

--- a/megaavr/libraries/Comparator/src/Comparator.cpp
+++ b/megaavr/libraries/Comparator/src/Comparator.cpp
@@ -1,75 +1,106 @@
 #include "Comparator.h"
 
-AnalogComparator Comparator(0, AC0);
+#if defined(AC0_AC_vect)
+AnalogComparator Comparator0(0, AC0, PORTD.PIN2CTRL, PORTE.PIN0CTRL, PORTE.PIN2CTRL, PORTD.PIN6CTRL, PORTD.PIN3CTRL, PORTD.PIN0CTRL, PORTD.PIN7CTRL);
+#endif
+#if defined(AC1_AC_vect)
+AnalogComparator Comparator1(1, AC1, PORTD.PIN2CTRL, PORTD.PIN3CTRL, PORTD.PIN4CTRL, PORTD.PIN6CTRL, PORTD.PIN5CTRL, PORTD.PIN0CTRL, PORTD.PIN7CTRL);
+#endif
+#if defined(AC2_AC_vect)
+AnalogComparator Comparator2(2, AC2, PORTD.PIN2CTRL, PORTD.PIN4CTRL, PORTE.PIN1CTRL, PORTD.PIN6CTRL, PORTD.PIN7CTRL, PORTD.PIN0CTRL, PORTD.PIN7CTRL);
+#endif
 
 // Array for storing ISR function pointers
-#if defined(AC2_AC_vect)
-static volatile voidFuncPtr intFuncAC[3];
+#if defined(AC0_AC_vect)
+static volatile voidFuncPtr intFuncAC[1];
 #elif defined(AC1_AC_vect)
 static volatile voidFuncPtr intFuncAC[2];
-#elif defined(AC0_AC_vect)
-static volatile voidFuncPtr intFuncAC[1];
+#elif defined(AC2_AC_vect)
+static volatile voidFuncPtr intFuncAC[3];
 #else
 #error target does not have an analog comparator!
 #endif
 
 
-AnalogComparator::AnalogComparator(const uint8_t comp_number, AC_t& ac) : comparator_number(comp_number), AC(ac)     
-{
-}
+AnalogComparator::AnalogComparator(
+                                   const uint8_t comp_number,
+                                   AC_t& ac,
+                                   register8_t& in0_p,
+                                   register8_t& in1_p,
+                                   register8_t& in2_p,
+                                   register8_t& in3_p,
+                                   register8_t& in0_n,
+                                   register8_t& in1_n,
+                                   register8_t& in2_n
+                                   )
+                                   : comparator_number(comp_number),
+                                     AC(ac),
+                                     IN0_P(in0_p),
+                                     IN1_P(in1_p),
+                                     IN2_P(in2_p),
+                                     IN3_P(in3_p),
+                                     IN0_N(in0_n),
+                                     IN1_N(in1_n),
+                                     IN2_N(in2_n) { }
 
 void AnalogComparator::init()
 {
   // Set voltage reference
   if(reference != ref::disable)
-  {
-    VREF.CTRLA = (VREF.CTRLA & ~VREF_AC0REFSEL_AVDD_gc) | reference;
-    VREF.CTRLB = VREF_AC0REFEN_bm;
-  }
+    VREF.ACREF = VREF_ALWAYSON_bm | reference;
   else
-    VREF.CTRLB &= ~VREF_AC0REFEN_bm;
+    VREF.ACREF &= ~VREF_ALWAYSON_bm;
 
   // Set DACREF
   AC.DACREF = dacref;
 
   // Set hysteresis
   AC.CTRLA = (AC.CTRLA & ~AC_HYSMODE_gm) | hysteresis;
-  
+
   // Set inputs
   if(input_p == in_p::in0)
-    PORTD.PIN2CTRL = PORT_ISC_INPUT_DISABLE_gc;
+    IN0_P = PORT_ISC_INPUT_DISABLE_gc;
   else if(input_p == in_p::in1)
-    PORTD.PIN4CTRL = PORT_ISC_INPUT_DISABLE_gc;
+    IN1_P = PORT_ISC_INPUT_DISABLE_gc;
   else if(input_p == in_p::in2)
-    PORTD.PIN6CTRL = PORT_ISC_INPUT_DISABLE_gc;
+    IN2_P = PORT_ISC_INPUT_DISABLE_gc;
   else if(input_p == in_p::in3)
-    PORTD.PIN1CTRL = PORT_ISC_INPUT_DISABLE_gc;
+    IN3_P = PORT_ISC_INPUT_DISABLE_gc;
   if(input_n == in_n::in0)
-    PORTD.PIN3CTRL = PORT_ISC_INPUT_DISABLE_gc;
+    IN0_N = PORT_ISC_INPUT_DISABLE_gc;
   else if(input_n == in_n::in1)
-    PORTD.PIN5CTRL = PORT_ISC_INPUT_DISABLE_gc;
+    IN1_N = PORT_ISC_INPUT_DISABLE_gc;
   else if(input_n == in_n::in2)
-    PORTD.PIN7CTRL = PORT_ISC_INPUT_DISABLE_gc;
-  AC.MUXCTRLA = (AC.MUXCTRLA & ~0x1B) | (input_p << 3) | input_n;
+    IN2_N = PORT_ISC_INPUT_DISABLE_gc;
+  AC.MUXCTRL = (AC.MUXCTRL & ~0x3f) | (input_p << 3) | input_n;
+
+  // Prepare for output pin swap
+  PORT_t& output_port = PORTA;
+  uint8_t pin_number = PIN7_bm;
+  if(output_swap == out::pin_swap)
+  {
+    output_port = PORTC;
+    pin_number = PIN6_bm;
+  }
 
   // Set output
   if(output == out::enable)
   {
-    AC.MUXCTRLA &= ~out::invert;
+    AC.MUXCTRL &= ~out::invert;
     AC.CTRLA |= out::enable;
-    PORTA.DIRSET = PIN7_bm;
+    output_port.DIRSET = pin_number;
   }
   else if(output == out::invert)
   {
-    AC.MUXCTRLA |= out::invert;
+    AC.MUXCTRL |= out::invert;
     AC.CTRLA |= out::enable;
-    PORTA.DIRSET = PIN7_bm;
+    output_port.DIRSET = pin_number;
   }
   else if(output == out::disable)
   {
-    AC.MUXCTRLA &= ~out::invert;
+    AC.MUXCTRL &= ~out::invert;
     AC.CTRLA &= ~out::enable;
-    PORTA.DIRCLR = PIN7_bm;
+    output_port.DIRCLR = pin_number;
   }
 }
 
@@ -93,25 +124,24 @@ void AnalogComparator::attachInterrupt(void (*userFunc)(void), uint8_t mode)
   {
     // Set RISING, FALLING or CHANGE interrupt trigger for the comparator output
     case RISING:
-      intmode = AC_INTMODE_POSEDGE_gc;
+      intmode = (AC_INTMODE_t)(AC_INTMODE1_bm | AC_INTMODE0_bm);
       break;
     case FALLING:
-      intmode = AC_INTMODE_NEGEDGE_gc;
+      intmode = (AC_INTMODE_t)AC_INTMODE1_bm;
       break;
     case CHANGE:
-      intmode = AC_INTMODE_BOTHEDGE_gc;
+      intmode = (AC_INTMODE_t)0x00;
       break;
     default:
       // Only RISING, FALLING and CHANGE is supported
       return;
   }
-  AC.CTRLA = (AC.CTRLA & ~AC_INTMODE_POSEDGE_gc) | intmode;
   
   // Store function pointer
   intFuncAC[comparator_number] = userFunc;
   
-  // Enable interrupt
-  AC.INTCTRL |= AC_CMP_bm;
+  // Set interrupt trigger and enable interrupt
+  AC.INTCTRL =  intmode | AC_CMP_bm;
 }
 
 void AnalogComparator::detachInterrupt()
@@ -127,7 +157,7 @@ ISR(AC0_AC_vect)
   intFuncAC[0]();
   
   // Clear flag
-  AC0.STATUS = AC_CMP_bm;
+  AC0.STATUS = AC_CMPIF_bm;
 }
 #endif
 
@@ -138,7 +168,7 @@ ISR(AC1_AC_vect)
   intFuncAC[1]();
   
   // Clear flag
-  AC1.STATUS = AC_CMP_bm;
+  AC1.STATUS = AC_CMPIF_bm;
 }
 #endif
 
@@ -149,6 +179,6 @@ ISR(AC2_AC_vect)
   intFuncAC[2]();
   
   // Clear flag
-  AC2.STATUS = AC_CMP_bm;
+  AC2.STATUS = AC_CMPIF_bm;
 }
 #endif

--- a/megaavr/libraries/Comparator/src/Comparator.cpp
+++ b/megaavr/libraries/Comparator/src/Comparator.cpp
@@ -1,4 +1,5 @@
 #include "Comparator.h"
+#include "Arduino.h"
 
 #if defined(AC0_AC_vect)
 AnalogComparator Comparator0(0, AC0, PORTD.PIN2CTRL, PORTE.PIN0CTRL, PORTE.PIN2CTRL, PORTD.PIN6CTRL, PORTD.PIN3CTRL, PORTD.PIN0CTRL, PORTD.PIN7CTRL);
@@ -11,12 +12,12 @@ AnalogComparator Comparator2(2, AC2, PORTD.PIN2CTRL, PORTD.PIN4CTRL, PORTE.PIN1C
 #endif
 
 // Array for storing ISR function pointers
-#if defined(AC0_AC_vect)
-static volatile voidFuncPtr intFuncAC[1];
-#elif defined(AC1_AC_vect)
-static volatile voidFuncPtr intFuncAC[2];
-#elif defined(AC2_AC_vect)
+#if defined(AC3_AC_vect)
 static volatile voidFuncPtr intFuncAC[3];
+#elif defined(AC2_AC_vect)
+static volatile voidFuncPtr intFuncAC[2];
+#elif defined(AC1_AC_vect)
+static volatile voidFuncPtr intFuncAC[1];
 #else
 #error target does not have an analog comparator!
 #endif
@@ -141,7 +142,7 @@ void AnalogComparator::attachInterrupt(void (*userFunc)(void), uint8_t mode)
   intFuncAC[comparator_number] = userFunc;
   
   // Set interrupt trigger and enable interrupt
-  AC.INTCTRL =  intmode | AC_CMP_bm;
+  AC.INTCTRL = intmode | AC_CMP_bm;
 }
 
 void AnalogComparator::detachInterrupt()
@@ -155,7 +156,7 @@ ISR(AC0_AC_vect)
 {
   // Run user function
   intFuncAC[0]();
-  
+
   // Clear flag
   AC0.STATUS = AC_CMPIF_bm;
 }
@@ -166,7 +167,7 @@ ISR(AC1_AC_vect)
 {
   // Run user function
   intFuncAC[1]();
-  
+
   // Clear flag
   AC1.STATUS = AC_CMPIF_bm;
 }
@@ -177,7 +178,7 @@ ISR(AC2_AC_vect)
 {
   // Run user function
   intFuncAC[2]();
-  
+
   // Clear flag
   AC2.STATUS = AC_CMPIF_bm;
 }

--- a/megaavr/libraries/Comparator/src/Comparator.h
+++ b/megaavr/libraries/Comparator/src/Comparator.h
@@ -16,6 +16,11 @@ namespace out
     no_swap  = 0x00,
     pin_swap = 0x01,
   };
+  enum initval_t : uint8_t
+  {
+    init_low  = 0x00,
+    init_high = 0x40,
+  };
 };
 
 namespace hyst
@@ -86,6 +91,7 @@ class AnalogComparator
 
     out::output_t      output = out::disable;
     out::pinswap_t     output_swap = out::no_swap;
+    out::initval_t     output_initval = out::init_low;
     hyst::hysteresis_t hysteresis = hyst::disable;
     in_p::inputP_t     input_p = in_p::in0;
     in_n::inputN_t     input_n = in_n::in0;

--- a/megaavr/libraries/Comparator/src/Comparator.h
+++ b/megaavr/libraries/Comparator/src/Comparator.h
@@ -11,6 +11,11 @@ namespace out
     enable  = 0x40,
     invert  = 0x80,
   };
+  enum pinswap_t : uint8_t
+  {
+    no_swap  = 0x00,
+    pin_swap = 0x01,
+  };
 };
 
 namespace hyst
@@ -50,20 +55,29 @@ namespace ref
 {
   enum reference_t : uint8_t
   {
-    vref_0v55 = 0x00, // 0.55V
-    vref_1v1  = 0x01, // 1.1V
-    vref_1v5  = 0x04, // 1.5V
-    vref_2v5  = 0x02, // 2.5V
-    vref_4v3  = 0x03, // 4.3V
-    vref_avcc = 0x07, // Vcc
-    disable   = 0x08,
+    vref_1v024 = 0x00, // 1.024V
+    vref_2v048 = 0x01, // 2.048V
+    vref_2v500 = 0x03, // 2.5V
+    vref_2v5   = 0x03,
+    vref_4v096 = 0x02, // 4.096V
+    vref_vdd   = 0x05, // VDD as reference
+    vref_vrefa = 0x06, // External reference from the VREFA pin
+    disable    = 0x08,
   };
 };
 
 class AnalogComparator
 {
   public:
-    AnalogComparator(const uint8_t comparator_number, AC_t& ac);
+    AnalogComparator(const uint8_t comparator_number,
+                     AC_t& ac,
+                     register8_t &in0_p,
+                     register8_t &in1_p,
+                     register8_t &in2_p,
+                     register8_t &in3_p,
+                     register8_t &in0_n,
+                     register8_t &in1_n,
+                     register8_t &in2_n);
     void init();
     void start(bool state = true);
     void stop();
@@ -71,6 +85,7 @@ class AnalogComparator
     void detachInterrupt();
 
     out::output_t      output = out::disable;
+    out::pinswap_t     output_swap = out::no_swap;
     hyst::hysteresis_t hysteresis = hyst::disable;
     in_p::inputP_t     input_p = in_p::in0;
     in_n::inputN_t     input_n = in_n::in0;
@@ -80,12 +95,27 @@ class AnalogComparator
   private:
     const uint8_t comparator_number;
     AC_t& AC;
+    register8_t& IN0_P;
+    register8_t& IN1_P;
+    register8_t& IN2_P;
+    register8_t& IN3_P;
+    register8_t& IN0_N;
+    register8_t& IN1_N;
+    register8_t& IN2_N;
     bool enable = false;   
 };
 
 #if defined(AC0_AC_vect)
 extern AnalogComparator Comparator0;
 #define Comparator Comparator0
+#endif
+
+#if defined(AC1_AC_vect)
+extern AnalogComparator Comparator1;
+#endif
+
+#if defined(AC2_AC_vect)
+extern AnalogComparator Comparator2;
 #endif
 
 #endif


### PR DESCRIPTION
I've just received some yellow PCBs with various AVR DA chips mounted. However, I've not yet test them.

Meanwhile, I've done some work on the comparator library to make it work with DA/DB hardware. There probably are bugs in here, so we should probably both test a few examples on real hardware.

If this turns out to be a success, there's no reason why I can't create a very similar library for the built-in ZCD hardware too!