### PR TITLE
Add CI workflow to do Arduino project-specific linting

### DIFF
--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -1,0 +1,25 @@
+name: Arduino Lint
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage caused by new rules added to Arduino Lint.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      # See: https://github.com/arduino/arduino-lint-action#readme
+      - name: Arduino Lint
+        uses: arduino/arduino-lint-action@v1
+        with:
+          path: megaavr


### PR DESCRIPTION
On every push, pull request, and periodically, run [Arduino Lint](https://github.com/arduino/arduino-lint) to check for common problems not related to the project code.

Reference: https://forum.arduino.cc/index.php?topic=723447.msg4877476#msg4877476

Demonstration workflow run: https://github.com/per1234/DxCore/runs/1793250086?check_suite_focus=true