### PR TITLE
Rename TCA count registers

### DIFF
--- a/megaavr/libraries/Event/README.md
+++ b/megaavr/libraries/Event/README.md
@@ -196,10 +196,10 @@ Below is a table with all of the event users for the AVR Dx-series parts.
 | `user::usart3_irda`     |                                    |
 | `user::usart4_irda`     |                                    |
 | `user::usart5_irda`     |                                    |
-| `user::tca0_cnta`       |                                    |
-| `user::tca0_cntb`       |                                    |
-| `user::tca1_cnta`       |                                    |
-| `user::tca1_cntb`       |                                    |
+| `user::tca0_cnt_a`      |                                    |
+| `user::tca0_cnt_b`      |                                    |
+| `user::tca1_cnt_a`      |                                    |
+| `user::tca1_cnt_b`      |                                    |
 | `user::tcb0_capt`       |                                    |
 | `user::tcb0_cnt`        |                                    |
 | `user::tcb1_capt`       |                                    |

--- a/megaavr/libraries/Event/src/Event.h
+++ b/megaavr/libraries/Event/src/Event.h
@@ -457,10 +457,10 @@ namespace user {
 #     if defined(USART5)
       usart5_irda    = 0x1A,
 #     endif
-      tca0_cnta      = 0x1B,
-      tca0_cntb      = 0x1C,
-      tca1_cnta      = 0x1D,
-      tca1_cntb      = 0x1E,
+      tca0_cnt_a     = 0x1B,
+      tca0_cnt_b     = 0x1C,
+      tca1_cnt_a     = 0x1D,
+      tca1_cnt_b     = 0x1E,
       tcb0_capt      = 0x1F,
       tcb0_cnt       = 0x20,
       tcb1_capt      = 0x21,
@@ -537,10 +537,10 @@ namespace user {
 #     if defined(USART5)
       usart5_irda    = 0x19,
 #     endif
-      tca0_cnta      = 0x1A,
-      tca0_cntb      = 0x1B,
-      tca1_cnta      = 0x1C,
-      tca1_cntb      = 0x1D,
+      tca0_cnt_a     = 0x1A,
+      tca0_cnt_b     = 0x1B,
+      tca1_cnt_a     = 0x1C,
+      tca1_cnt_b     = 0x1D,
       tcb0_capt      = 0x1E,
       tcb0_cnt       = 0x1F,
       tcb1_capt      = 0x20,


### PR DESCRIPTION
Initially your idea.
https://github.com/MCUdude/MegaCoreX/issues/108

tcaN_cnta -> tcaN_cnt_a
tcaN_cntb -> tcaN_cnt_b
