### PR TITLE
Add ability for library static linking

### DIFF
--- a/megaavr/extras/LinkingAgainstStaticLibrary.md
+++ b/megaavr/extras/LinkingAgainstStaticLibrary.md
@@ -1,0 +1,25 @@
+# Linking against static library
+
+In some uses cases, it might be convenient to link against a static library/archive rather than compiling the code each time. For example if you don't have access to the source files, just the headers and the archive, you want to reduce compilation time for a larger codebase or want to have a bunch of board specific code for a larger library. The downside with using a library is that the code size will increase, since things are statically linked and the compiler can do fewer tricks on what it has got at hand.
+
+As things are with the Arduino environment at the moment, this requires your source code to be an Arduino library as well. This isn't a big deal, there are two steps:
+
+1. Move your project to Arduino's library folder (usually in the `Documents\Arduino\libraries` folder in your home folder on Windows and in the `Arduino/libraries` folder in your home folder on linux). More information [here](https://www.arduino.cc/en/hacking/libraries).
+2. Create a `library.properties` file according to this [specification](https://arduino.github.io/arduino-cli/latest/library-specification/) in the root of your library. An example is: 
+
+```
+name=your-library
+version=1.0.0
+author=Your name <your email>
+maintainer=Your name <your email>
+sentence=Test library 
+paragraph=Links an archive
+category=Other
+url=http://example.com/
+architectures=*
+precompiled=true
+```
+
+The `precompiled` keyword enables us to link against some archive. The archives have to be placed in `src/<board>/`, as detailed [here](https://arduino.github.io/arduino-cli/latest/library-specification/#precompiled-binaries). Board has to for example be `avr128db64`. 
+
+After this, you should be able to compile your code against the archive.

--- a/megaavr/platform.txt
+++ b/megaavr/platform.txt
@@ -46,6 +46,7 @@ compiler.elf2hex.flags=-O ihex -R .eeprom
 compiler.elf2hex.bin.flags=-O binary -R .eeprom
 compiler.elf2hex.cmd=avr-objcopy
 compiler.ldflags=
+compiler.libraries.ldflags=
 compiler.size.cmd=avr-size
 
 # This can be overridden in boards.txt
@@ -78,7 +79,7 @@ archive_file_path={build.path}/{archive_file}
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}"
 
 ## Combine gc-sections, archives, and objects
-recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mmcu={build.mcu} {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" {object_files} "{build.path}/{archive_file}" "-L{build.path}" -lm
+recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mmcu={build.mcu} {compiler.c.elf.extra_flags} {compiler.ldflags} -o "{build.path}/{build.project_name}.elf" {object_files} {compiler.libraries.ldflags} "{build.path}/{archive_file}" "-L{build.path}" -lm
 
 ## Create output files (.eep and .hex)
 recipe.objcopy.eep.pattern="{compiler.path}{compiler.objcopy.cmd}" {compiler.objcopy.eep.flags} {compiler.objcopy.eep.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.eep"


### PR DESCRIPTION
Updates the platform.txt so that other libraries can use static archives. Taken from here: https://github.com/arduino/ArduinoCore-avr/blob/master/platform.txt. The functionality is described here: https://arduino.github.io/arduino-cli/latest/library-specification/#precompiled-binaries