### PR TITLE
Verify presence of TWI 1 before creating SDA1/SCL1

### DIFF
--- a/megaavr/cores/dxcore/pinswap.h
+++ b/megaavr/cores/dxcore/pinswap.h
@@ -71,9 +71,10 @@ static const uint8_t SCL = PIN_WIRE_SCL;
   static const uint8_t SDA1_ALT2 = PIN_WIRE1_SDA_PINSWAP_2;
   static const uint8_t SCL1_ALT2 = PIN_WIRE1_SCL_PINSWAP_2;
 #endif
-static const uint8_t SDA1 = PIN_WIRE1_SDA;
-static const uint8_t SCL1 = PIN_WIRE1_SCL;
-
+#ifdef PIN_WIRE1_SCL
+  static const uint8_t SDA1 = PIN_WIRE1_SDA;
+  static const uint8_t SCL1 = PIN_WIRE1_SCL;
+#endif
 
 #ifdef PIN_WIRE1_SCL
   #ifdef PIN_WIRE1_SCL_PINSWAP_2


### PR DESCRIPTION
TWI 1 doesn't exist for 28-pin parts, so SDA1/SCL1 shouldn't be created. This resolves issue #138.