### PR TITLE
Fixed TWI error return

### DIFF
--- a/megaavr/libraries/Wire/src/Wire.cpp
+++ b/megaavr/libraries/Wire/src/Wire.cpp
@@ -755,7 +755,7 @@ void TwoWire::onRequest(void (*function)(void)) {
 }
 
 
-#if defined(TWI_ERROR_ENABLED)
+#if defined(TWI_EXT_ERROR_ENABLED) && defined(TWI_ERROR_ENABLED)
 uint8_t TwoWire::returnError() {
   return vars._errors;
 }

--- a/megaavr/libraries/Wire/src/Wire.h
+++ b/megaavr/libraries/Wire/src/Wire.h
@@ -143,7 +143,7 @@ class TwoWire: public Stream {
     }
     using Print::write;
 
-    #if defined(TWI_ERROR_ENABLED)
+    #if defined(TWI_EXT_ERROR_ENABLED) && defined(TWI_ERROR_ENABLED)
     uint8_t returnError();
     #endif
 

--- a/megaavr/libraries/Wire/src/twi.c
+++ b/megaavr/libraries/Wire/src/twi.c
@@ -355,7 +355,7 @@ uint8_t TWI_MasterWrite(struct twiData *_data, bool send_stop)  {
     #if defined(TWI_TIMEOUT_ENABLE)
       if (++timeout > (F_CPU/1000)) {
         if        (currentSM == TWI_BUSSTATE_OWNER_gc) {
-          TWI_SET_EXT_ERROR(TWI_ERR_TIMEOUT);
+          TWI_SET_ERROR(TWI_ERR_TIMEOUT);
         } else if (currentSM == TWI_BUSSTATE_IDLE_gc) {
           TWI_SET_EXT_ERROR(TWI_ERR_PULLUP);
         } else {

--- a/megaavr/libraries/Wire/src/twi.h
+++ b/megaavr/libraries/Wire/src/twi.h
@@ -113,13 +113,13 @@ SOFTWARE.
 #define  TWI_ERR_ACK_ADR       2  // Address was NACKed on Master write
 #define  TWI_ERR_ACK_DAT       3  // Data was NACKed on Master write
 #define  TWI_ERR_UNDEFINED     4  // Software can't tell error source
+#define  TWI_ERR_TIMEOUT       5  // TWI Timed out on data rx/tx
 
 // Errors that are made to help finding errors on TWI lines. Only indications
 #define  TWI_ERR_PULLUP        11 // Likely problem with pull-ups
-#define  TWI_ERR_TIMEOUT       12 // TWI Timed out on data rx/tx
-#define  TWI_ERR_BUS_ARB       13 // Bus error and/or Arbitration lost
-#define  TWI_ERR_BUF_OVERFLOW  14 // Buffer overflow on master read
-#define  TWI_ERR_CLKHLD        15 // Something's holding the clock
+#define  TWI_ERR_BUS_ARB       12 // Bus error and/or Arbitration lost
+#define  TWI_ERR_BUF_OVERFLOW  13 // Buffer overflow on master read
+#define  TWI_ERR_CLKHLD        14 // Something's holding the clock
 
 #if defined(TWI_ERROR_ENABLED)
   #define TWI_ERROR_VAR    twi_error
@@ -141,7 +141,7 @@ SOFTWARE.
   #define TWIR_GET_ERROR        TWIR_ERROR_VAR
   #define TWIR_CHK_ERROR(x)     TWIR_ERROR_VAR == x
   #define TWIR_SET_ERROR(x)     TWIR_ERROR_VAR = x
-  
+
   #define TWI_SET_EXT_ERROR(x)  TWI_ERROR_VAR = x
 #else
   #define TWIR_ERROR_VAR        {}
@@ -149,7 +149,7 @@ SOFTWARE.
   #define TWIR_GET_ERROR        {0}
   #define TWIR_CHK_ERROR(x)     (true)
   #define TWIR_SET_ERROR(x)     {}
-  
+
   #define TWI_SET_EXT_ERROR(x)  {}
 #endif
 


### PR DESCRIPTION
Since I had most of the error logic already in the code, just disabled, I was able to fix the problem easily.

I also figured out how that could happen, The old library was using a WriteRead function and while write returns errors, the read returns readBytes. I got confused there, obviously, thinking that both return the written/readBytes