### PR TITLE
linear buffers for Wire

### DIFF
--- a/megaavr/libraries/Wire/examples/mixed_bag/mixed_bag.ino
+++ b/megaavr/libraries/Wire/examples/mixed_bag/mixed_bag.ino
@@ -107,11 +107,12 @@ void sendDataWire() {
   if (firstElement == 'r' || firstElement == 'R') {   // check if the first element is an 'r' or 'R'
     if (4 == Wire.requestFrom(0x54, 4, 0x01)) {       // request from slave
       while (Wire.available()) {
+        uint32_t ms;
         ms  = (uint32_t)Wire.read();                  // read out 32-bit wide data
         ms |= (uint32_t)Wire.read() <<  8;
         ms |= (uint32_t)Wire.read() << 16;
         ms |= (uint32_t)Wire.read() << 24;
-        MySerial.println(ls);
+        MySerial.println(ms);
       }
     } else {
       MySerial.println("Wire.requestFrom() timed out!");

--- a/megaavr/libraries/Wire/src/Wire.cpp
+++ b/megaavr/libraries/Wire/src/Wire.cpp
@@ -289,7 +289,7 @@ uint8_t TwoWire::requestFrom(uint8_t  address,  uint8_t  quantity,  uint8_t send
  *            This function only saves the client address in the structure, it does
  *            not perform any transmissions.
  *            a write() will fill the transmit buffer. write() has to be called after
- *            beginTransmission() was called
+ *            beginTransmission() was called. Any write() before beginTransmission() will be lost
  *
  *@param      uint8_t address - the address of the client
  *
@@ -297,11 +297,9 @@ uint8_t TwoWire::requestFrom(uint8_t  address,  uint8_t  quantity,  uint8_t send
  */
 void TwoWire::beginTransmission(uint8_t address) {
   #if defined(TWI_MERGE_BUFFERS)                  // Same Buffers for tx/rx
-    uint8_t* txHead  = &(vars._trHead);
-    uint8_t* txTail  = &(vars._trTail);
+    uint8_t* txHead  = &(vars._bytesToReadWrite);
   #else                                           // Separate tx/rx Buffers
-    uint8_t* txHead  = &(vars._txHead);
-    uint8_t* txTail  = &(vars._txTail);
+    uint8_t* txHead  = &(vars._bytesToWrite);
   #endif
   if (__builtin_constant_p(address) > 0x7F) {     // Compile-time check if address is actually 7 bit long
     badArg("Supplied address seems to be 8 bit. Only 7-bit-addresses are supported");
@@ -309,7 +307,7 @@ void TwoWire::beginTransmission(uint8_t address) {
   }
   // set address of targeted client
   vars._clientAddress = address << 1;
-  (*txTail) = (*txHead);  // reset transmitBuffer
+  (*txHead) = 0;  // fill buffer from 0
 }
 
 
@@ -358,40 +356,34 @@ uint8_t TwoWire::endTransmission(bool sendStop) {
  */
 size_t TwoWire::write(uint8_t data) {
 
-  uint8_t nextHead;
   uint8_t* txHead;
-  uint8_t* txTail;
   uint8_t* txBuffer;
 
   #if defined(TWI_MANDS)                   // Add following if host and client are split
     if (vars._bools._toggleStreamFn == 0x01) {
-      txHead   = &(vars._trHeadS);
-      txTail   = &(vars._trTailS);
+      txHead   = &(vars._bytesToReadWriteS);
       txBuffer =   vars._trBufferS;
     } else
   #endif
   {
     #if defined(TWI_MERGE_BUFFERS)         // Same Buffers for tx/rx
-      txHead   = &(vars._trHead);
-      txTail   = &(vars._trTail);
+      txHead   = &(vars._bytesToReadWrite);
       txBuffer =   vars._trBuffer;
     #else                                  // Separate tx/rx Buffers
-      txHead   = &(vars._txHead);
-      txTail   = &(vars._txTail);
+      txHead   = &(vars._bytesToWrite);
       txBuffer =   vars._txBuffer;
     #endif
   }
 
   /* Put byte in txBuffer */
-  nextHead = TWI_advancePosition(*txHead);
 
-  if (nextHead == (*txTail)) {
-    return 0;                             // Buffer full, stop accepting data
+  if ((*txHead) < BUFFER_LENGTH) {      // while buffer not full, write to it
+    txBuffer[(*txHead)] = data;             // Load data into the buffer
+    (*txHead)++;                            // advancing the head
+    return 1;
+  } else {
+    return 0;
   }
-  txBuffer[(*txHead)] = data;             // Load data into the buffer
-  (*txHead) = nextHead;                   // advancing the head
-
-  return 1;
 }
 
 
@@ -408,12 +400,13 @@ size_t TwoWire::write(uint8_t data) {
  *@retval     amount of bytes copied
  */
 size_t TwoWire::write(const uint8_t *data, size_t quantity) {
-
-  for (size_t i = 0; i < quantity; i++) {
-    write(*(data + i));
+  uint8_t i = 0;  //uint8_t since we don't use bigger buffers
+  
+  for (; i < (uint8_t)quantity; i++) {    // limit quantity to 255 to avoid lock up
+    if (write(*(data + i)) == 0) break;   // break if buffer full
   }
 
-  return quantity;
+  return i;
 }
 
 
@@ -430,8 +423,42 @@ size_t TwoWire::write(const uint8_t *data, size_t quantity) {
  *@return     int
  *@retval     amount of bytes available to read from the host buffer
  */
+ 
+   /**
+ *@brief      TWI_Available returns the amount of bytes that are available to read in the host or client buffer
+ *
+ *            This function is placed in this file because the client interrupt handler needs it too.
+ *            This file has no concept of the Wire object.
+ *            In MANDS mode, when called from
+ *            user_onRequest() or user_onReceive() it will return the number from the client buffer
+ *            due to the _toggleStreamFn flag
+ *            Will return amount of bytes to be written in the buffer when called in Master-MORS 
+ *
+ *@param      struct twiData *_data is a pointer to the structure that holds the variables
+ *              of a Wire object. Following struct elements are used in this function:
+ *                _bools._toggleStreamFn
+ *                _rxHead(S)
+ *                _rxTail(S)
+ *
+ *@return     uint8_t
+ *@retval     amount of bytes available to read from the host or client buffer
+ */
 int TwoWire::available(void) {
-  return TWI_Available(&vars);
+  int rxHead;
+  #if defined(TWI_MANDS)                          // Add following if host and client are split
+    if (vars._bools._toggleStreamFn == 0x01) {
+      rxHead  = &(vars._bytesToReadWriteS) - &(vars._bytesReadWrittenS);
+    } else
+  #endif
+  {
+    #if defined(TWI_MERGE_BUFFERS)                // Same Buffers for tx/rx
+      rxHead  = &(vars._bytesToReadWrite) - &(vars._bytesReadWritten);
+    #else                                         // Separate tx/rx Buffers
+      rxHead  = &(vars._bytesToRead) - &(vars._bytesRead);
+    #endif
+  }
+  
+  return rxHead;
 }
 
 
@@ -456,30 +483,30 @@ int TwoWire::read(void) {
 
   #if defined(TWI_MANDS)                         // Add following if host and client are split
     if (vars._bools._toggleStreamFn == 0x01) {
-      rxHead   = &(vars._trHeadS);
-      rxTail   = &(vars._trTailS);
+      rxHead   = &(vars._bytesToReadWriteS);
+      rxTail   = &(vars._bytesReadWrittenS);
       rxBuffer =   vars._trBufferS;
     } else
   #endif
   {
     #if defined(TWI_MERGE_BUFFERS)               // Same Buffers for tx/rx
-      rxHead   = &(vars._trHead);
-      rxTail   = &(vars._trTail);
+      rxHead   = &(vars._bytesToReadWrite);
+      rxTail   = &(vars._bytesReadWritten);
       rxBuffer =   vars._trBuffer;
     #else                                        // Separate tx/rx Buffers
-      rxHead   = &(vars._rxHead);
-      rxTail   = &(vars._rxTail);
+      rxHead   = &(vars._bytesToRead);
+      rxTail   = &(vars._bytesRead);
       rxBuffer =   vars._rxBuffer;
     #endif
   }
 
 
-  if ((*rxHead) == (*rxTail)) {   // if the head isn't ahead of the tail,
-    return -1;                    // we don't have any characters
-  } else {
+  if ((*rxTail) < (*rxHead)) {   // if there are bytes to read
     uint8_t c = rxBuffer[(*rxTail)];
-    (*rxTail) = TWI_advancePosition(*rxTail);
+    (*rxTail)++;
     return c;
+  } else {                      // No bytes to read. At this point, rxTail moved up to
+    return -1;                  // rxHead. To reset both to 0, a MasterRead or AddrWrite has to be called
   }
 }
 
@@ -502,28 +529,29 @@ int TwoWire::peek(void) {
   uint8_t* rxTail;
   uint8_t* rxBuffer;
 
-  #if defined(TWI_MANDS)                          // Add following if host and client are split
+  #if defined(TWI_MANDS)                         // Add following if host and client are split
     if (vars._bools._toggleStreamFn == 0x01) {
-        rxHead   = &(vars._trHeadS);
-        rxTail   = &(vars._trTailS);
-        rxBuffer =   vars._trBufferS;
+      rxHead   = &(vars._bytesToReadWriteS);
+      rxTail   = &(vars._bytesReadWrittenS);
+      rxBuffer =   vars._trBufferS;
     } else
   #endif
   {
-    #if defined(TWI_MERGE_BUFFERS)                // Same Buffers for tx/rx
-      rxHead   = &(vars._trHead);
-      rxTail   = &(vars._trTail);
+    #if defined(TWI_MERGE_BUFFERS)               // Same Buffers for tx/rx
+      rxHead   = &(vars._bytesToReadWrite);
+      rxTail   = &(vars._bytesReadWritten);
       rxBuffer =   vars._trBuffer;
-    #else                                         // Separate tx/rx Buffers
-      rxHead   = &(vars._rxHead);
-      rxTail   = &(vars._rxTail);
+    #else                                        // Separate tx/rx Buffers
+      rxHead   = &(vars._bytesToRead);
+      rxTail   = &(vars._bytesRead);
       rxBuffer =   vars._rxBuffer;
     #endif
   }
-  if ((*rxHead) == (*rxTail)) {
-    return -1;
-  } else {
+  
+  if ((*rxTail) < (*rxHead)) {   // if there are bytes to read
     return rxBuffer[(*rxTail)];
+  } else {      // No bytes to read
+    return -1;
   }
 }
 
@@ -536,17 +564,6 @@ int TwoWire::peek(void) {
  *@return     void
  */
 void TwoWire::flush(void) {
-  #if defined(TWI_MERGE_BUFFERS)
-    vars._trTail = vars._trHead;
-  #else
-    vars._rxTail = vars._rxHead;
-    vars._txTail = vars._txHead;
-  #endif
-
-  #if defined (TWI_MANDS)
-    vars._trTailS = vars._trHeadS;
-  #endif
-
   /* Turn off and on TWI module */
   TWI_Flush(&vars);
 }
@@ -571,7 +588,8 @@ uint8_t TwoWire::getIncomingAddress(void) {
 }
 
 /**
- *@brief      getBytesRead provides a facility for the slave to check how many bytes were read.
+ *@brief      getBytesRead provides a facility for the slave to check how many bytes were
+ *              successfully read by the master.
  *
  *            Useful for implementing a "register model" like most I2C hardware does.
  *            Calling this will reset the counter, since it is an unusual use case for
@@ -583,9 +601,18 @@ uint8_t TwoWire::getIncomingAddress(void) {
  */
 
 uint8_t TwoWire::getBytesRead() {
-  uint8_t bytes = vars._slaveBytesRead;
-  vars._slaveBytesRead = 0;
-  return bytes;
+  uint8_t* txTail;
+  #if defined(TWI_MANDS)                         // Add following if host and client are split
+      txTail   = &(vars._bytesReadWrittenS);
+  #else
+    #if defined(TWI_MERGE_BUFFERS)               // Same Buffers for tx/rx
+      txTail   = &(vars._bytesReadWritten);
+    #else                                        // Separate tx/rx Buffers
+      txTail   = &(vars._bytesWritten);
+    #endif
+  #endif
+  // txTail variable (what ever applies on the mode) is reset on every slave AddrRead
+  return (*txTail);
 }
 
 /**

--- a/megaavr/libraries/Wire/src/Wire.cpp
+++ b/megaavr/libraries/Wire/src/Wire.cpp
@@ -353,7 +353,6 @@ uint8_t TwoWire::endTransmission(bool sendStop) {
  *@retval     1 if successful, 0 if the buffer is full
  */
 size_t TwoWire::write(uint8_t data) {
-
   uint8_t* txHead;
   uint8_t* txBuffer;
 
@@ -399,7 +398,7 @@ size_t TwoWire::write(uint8_t data) {
  */
 size_t TwoWire::write(const uint8_t *data, size_t quantity) {
   uint8_t i = 0;  // uint8_t since we don't use bigger buffers
-  
+
   for (; i < (uint8_t)quantity; i++) {    // limit quantity to 255 to avoid lock up
     if (write(*(data + i)) == 0) break;   // break if buffer full
   }
@@ -436,7 +435,6 @@ int TwoWire::available(void) {
       rxHead  = vars._bytesToRead - vars._bytesRead;
     #endif
   }
-  
   return rxHead;
 }
 
@@ -455,7 +453,6 @@ int TwoWire::available(void) {
  *@retval     byte in the buffer or -1 if buffer is empty
  */
 int TwoWire::read(void) {
-
   uint8_t* rxHead;
   uint8_t* rxTail;
   uint8_t* rxBuffer;
@@ -503,7 +500,6 @@ int TwoWire::read(void) {
  *@retval     byte in the buffer or -1 if buffer is empty
  */
 int TwoWire::peek(void) {
-
   uint8_t* rxHead;
   uint8_t* rxTail;
   uint8_t* rxBuffer;
@@ -526,7 +522,7 @@ int TwoWire::peek(void) {
       rxBuffer =   vars._rxBuffer;
     #endif
   }
-  
+
   if ((*rxTail) < (*rxHead)) {   // if there are bytes to read
     return rxBuffer[(*rxTail)];
   } else {      // No bytes to read

--- a/megaavr/libraries/Wire/src/Wire.cpp
+++ b/megaavr/libraries/Wire/src/Wire.cpp
@@ -51,8 +51,6 @@ extern "C" {    // compiler was complaining when I put twi.h into the upper C in
  */
 TwoWire::TwoWire(TWI_t *twi_module) {
   vars._module = twi_module;
-  // vars.user_onRequest = NULL;  // Make sure to initialize this pointers
-  // vars.user_onReceive = NULL;  // This avoids weird jumps should something unexpected happen
 }
 
 /**
@@ -400,7 +398,7 @@ size_t TwoWire::write(uint8_t data) {
  *@retval     amount of bytes copied
  */
 size_t TwoWire::write(const uint8_t *data, size_t quantity) {
-  uint8_t i = 0;  //uint8_t since we don't use bigger buffers
+  uint8_t i = 0;  // uint8_t since we don't use bigger buffers
   
   for (; i < (uint8_t)quantity; i++) {    // limit quantity to 255 to avoid lock up
     if (write(*(data + i)) == 0) break;   // break if buffer full
@@ -423,38 +421,19 @@ size_t TwoWire::write(const uint8_t *data, size_t quantity) {
  *@return     int
  *@retval     amount of bytes available to read from the host buffer
  */
- 
-   /**
- *@brief      TWI_Available returns the amount of bytes that are available to read in the host or client buffer
- *
- *            This function is placed in this file because the client interrupt handler needs it too.
- *            This file has no concept of the Wire object.
- *            In MANDS mode, when called from
- *            user_onRequest() or user_onReceive() it will return the number from the client buffer
- *            due to the _toggleStreamFn flag
- *            Will return amount of bytes to be written in the buffer when called in Master-MORS 
- *
- *@param      struct twiData *_data is a pointer to the structure that holds the variables
- *              of a Wire object. Following struct elements are used in this function:
- *                _bools._toggleStreamFn
- *                _rxHead(S)
- *                _rxTail(S)
- *
- *@return     uint8_t
- *@retval     amount of bytes available to read from the host or client buffer
- */
+
 int TwoWire::available(void) {
   int rxHead;
   #if defined(TWI_MANDS)                          // Add following if host and client are split
     if (vars._bools._toggleStreamFn == 0x01) {
-      rxHead  = &(vars._bytesToReadWriteS) - &(vars._bytesReadWrittenS);
+      rxHead  = vars._bytesToReadWriteS - vars._bytesReadWrittenS;
     } else
   #endif
   {
     #if defined(TWI_MERGE_BUFFERS)                // Same Buffers for tx/rx
-      rxHead  = &(vars._bytesToReadWrite) - &(vars._bytesReadWritten);
+      rxHead  = vars._bytesToReadWrite - vars._bytesReadWritten;
     #else                                         // Separate tx/rx Buffers
-      rxHead  = &(vars._bytesToRead) - &(vars._bytesRead);
+      rxHead  = vars._bytesToRead - vars._bytesRead;
     #endif
   }
   

--- a/megaavr/libraries/Wire/src/twi.c
+++ b/megaavr/libraries/Wire/src/twi.c
@@ -102,10 +102,10 @@ void TWI_SlaveInit(struct twiData *_data, uint8_t address, uint8_t receive_broad
     if (_data->_bools._clientEnabled  == 1) {  // Master is allowed to be enabled, don't re-enable the client though
       return;
     }
-  #else                                       // Master or Slave
-    if (_data->_bools._hostEnabled    == 1 || // If Master was enabled
-        _data->_bools._clientEnabled  == 1) { // or Slave was enabled
-    return;                                   // return and do nothing
+  #else                                         // Master or Slave
+    if (_data->_bools._hostEnabled    == 1 ||   // If Master was enabled
+        _data->_bools._clientEnabled  == 1) {   // or Slave was enabled
+    return;                                     // return and do nothing
     }
   #endif
 
@@ -380,7 +380,7 @@ uint8_t TWI_MasterRead(struct twiData *_data, uint8_t bytesToRead, bool send_sto
     uint8_t* rxTail   = &(_data->_bytesRead);
     uint8_t* rxBuffer =   _data->_rxBuffer;
   #endif
-  
+
   (*rxTail) = 0;                      // Reset counter
 
   TWI_t *module = _data->_module;     // Compiler treats the pointer to the TWI module as volatile and
@@ -388,14 +388,14 @@ uint8_t TWI_MasterRead(struct twiData *_data, uint8_t bytesToRead, bool send_sto
 
   TWIR_INIT_ERROR;             // local variable for errors
   uint8_t dataRead = 0;
-  
+
   if ((module->MSTATUS & TWI_BUSSTATE_gm) != TWI_BUSSTATE_UNKNOWN_gc) {
     uint8_t currentSM;
     uint8_t currentStatus;
     uint8_t command  = 0;
     uint16_t timeout = 0;
-    
-    module->MADDR = ADD_READ_BIT(_data->_clientAddress);  //Send Address with read bit
+
+    module->MADDR = ADD_READ_BIT(_data->_clientAddress);  // Send Address with read bit
 
     while (true) {
       currentStatus = module->MSTATUS;
@@ -415,9 +415,9 @@ uint8_t TWI_MasterRead(struct twiData *_data, uint8_t bytesToRead, bool send_sto
       #endif
 
       if (currentStatus & (TWI_ARBLOST_bm | TWI_BUSERR_bm)) {   // Check for Bus error
-        module->MSTATUS = (TWI_ARBLOST_bm | TWI_BUSERR_bm);      // reset error flags
-        TWIR_SET_ERROR(TWI_ERR_BUS_ARB);                         // set error flag
-        break;                                                   // leave TX loop
+        module->MSTATUS = (TWI_ARBLOST_bm | TWI_BUSERR_bm);     // reset error flags
+        TWIR_SET_ERROR(TWI_ERR_BUS_ARB);                        // set error flag
+        break;                                                  // leave TX loop
       }
 
       if (command != 0) {
@@ -434,7 +434,7 @@ uint8_t TWI_MasterRead(struct twiData *_data, uint8_t bytesToRead, bool send_sto
             rxBuffer[dataRead] = module->MDATA;      // save byte in the Buffer.
             dataRead++;                              // increment read counter
             timeout = 0;                             // reset timeout
-            
+
             if (dataRead < bytesToRead) {            // expecting more bytes, so
               module->MCTRLB = TWI_MCMD_RECVTRANS_gc;  // send an ACK so the Slave so it can send the next byte
             } else {                                 // Otherwise,
@@ -444,11 +444,11 @@ uint8_t TWI_MasterRead(struct twiData *_data, uint8_t bytesToRead, bool send_sto
                 break;
               }
             }
-            
+
           } else {                                        // Buffer overflow with the incoming byte
             TWIR_SET_ERROR(TWI_ERR_BUF_OVERFLOW);         // Set Error and
             command = TWI_ACKACT_bm | TWI_MCMD_STOP_gc;   // send STOP + NACK
-          } 
+          }
         } else if (currentStatus & TWI_WIF_bm) {  // Address NACKed
           TWIR_SET_ERROR(TWI_ERR_RXACK);          // set error flag
           command = TWI_MCMD_STOP_gc;             // free the bus
@@ -582,10 +582,10 @@ void SlaveIRQ_AddrRead(struct twiData *_data) {
 
                                             // There is no way to identify a REPSTART, so when a Master Read occurs after a Master write
   NotifyUser_onReceive(_data);              // Notify user program "onReceive" if necessary
-  
+
   (*txHead) = 0;                            // reset buffer positions so the Slave can start writing at zero.
   (*txTail) = 0;
-  
+
   NotifyUser_onRequest(_data);              // Notify user program "onRequest" if necessary
   _data->_module->SCTRLB = TWI_SCMD_RESPONSE_gc;  // "Execute Acknowledge Action succeeded by client data interrupt"
 }
@@ -595,13 +595,13 @@ void SlaveIRQ_AddrWrite(struct twiData *_data) {
     uint8_t* address = &(_data->_incomingAddress);
     uint8_t* rxHead  = &(_data->_bytesToReadWriteS);
     uint8_t* rxTail  = &(_data->_bytesReadWrittenS);
-    
+
   #else                                             // Slave using the Master buffer
     uint8_t*    address = &(_data->_clientAddress);
     #if defined(TWI_MERGE_BUFFERS)                  // Same Buffers for tx/rx
       uint8_t* rxHead   = &(_data->_bytesToReadWrite);
       uint8_t* rxTail   = &(_data->_bytesReadWritten);
-    #else 
+    #else
       uint8_t* rxHead   = &(_data->_bytesToRead);
       uint8_t* rxTail   = &(_data->_bytesRead);
     #endif
@@ -667,7 +667,6 @@ void SlaveIRQ_DataReadAck(struct twiData *_data) {
     #endif
   #endif
 
- 
   _data->_bools._ackMatters = true;             // start checking for NACK
   if ((*txTail) < (*txHead)) {                  // Data is available
     _data->_module->SDATA = txBuffer[(*txTail)];    // Writing to the register to send data
@@ -707,7 +706,7 @@ void SlaveIRQ_DataWrite(struct twiData *_data) {
     _data->_module->SCTRLB = TWI_ACKACT_bm | TWI_SCMD_COMPTRANS_gc;  // "Execute ACK Action succeeded by waiting for any Start (S/Sr) condition"
     (*rxHead) = 0;                                           // Dismiss all received Data since data integrity can't be guaranteed
     (*rxTail) = 0;  // Make sure available will return 0
-  }                               
+  }
 }
 
 /**

--- a/megaavr/libraries/Wire/src/twi.h
+++ b/megaavr/libraries/Wire/src/twi.h
@@ -79,17 +79,19 @@ SOFTWARE.
  * 32 byte buffers, many libraries implicitly depend >= 32 byte
  * buffers and will misbehave if the buffer used is smaller.
  * So even where it's painfully large portion of ram, we use
- * that.Similarly, most libraries will not make use of a larger one
+ * that. Similarly, most libraries will not make use of a larger one
  * Thus, we don't enlarge the buffer until we finally get to
  * the modern AVRs with >= 4k of RAM, where it doesn't really
- * matter anymore. At that point, enlarging the buffer to 130b
+ * matter any more. At that point, enlarging the buffer to 130b
  * allows for a 128b page write to the popular 24-series EEPROMs
  * Since the modern AVRs are lighter on EEPROM than classic ones
  * it is more likely that external storage would be needed.
  * SD cards are a poor choice for byte oriented data storage, in
- * addition to being astonishingly unrelible, and byte oriented
+ * addition to being astonishingly unreliable, and byte oriented
  * data storage is more useful for typical applications of AVRs
  * than file-oriented storage.
+ * If 130 bytes are not enough, the maximum supported buffer size
+ * is 256 bytes without modifications to the library.
  */
 #ifndef BUFFER_LENGTH
   #if (RAMSIZE < 256)

--- a/megaavr/libraries/Wire/src/twi.h
+++ b/megaavr/libraries/Wire/src/twi.h
@@ -104,10 +104,10 @@ SOFTWARE.
 #endif
 
 
-#define  TWI_TIMEOUT_ENABLE      // Enabled by default, might be disabled for debugging or other reasons
-#define  TWI_ERROR_ENABLED       // Enabled by default, TWI Master Write error functionality
-//#define TWI_READ_ERROR_ENABLED // Enabled on Master Read too
-//#define DISABLE_NEW_ERRORS     // Disables the new error codes and returns TWI_ERR_UNDEFINED instead.
+#define  TWI_TIMEOUT_ENABLE       // Enabled by default, might be disabled for debugging or other reasons
+#define  TWI_ERROR_ENABLED        // Enabled by default, TWI Master Write error functionality
+//#define TWI_READ_ERROR_ENABLED  // Enabled on Master Read too
+//#define DISABLE_NEW_ERRORS      // Disables the new error codes and returns TWI_ERR_UNDEFINED instead.
 
 // Errors from Arduino documentation:
 #define  TWI_ERR_SUCCESS         0x00  // Default
@@ -154,7 +154,7 @@ SOFTWARE.
   #define TWIR_CHK_ERROR(x)     TWIR_ERROR_VAR == x
   #define TWIR_SET_ERROR(x)     TWIR_ERROR_VAR = x
 
-  //#define TWI_SET_EXT_ERROR(x)  TWI_ERROR_VAR = x
+  // #define TWI_SET_EXT_ERROR(x)  TWI_ERROR_VAR = x
 #else
   #define TWIR_ERROR_VAR        {}
   #define TWIR_INIT_ERROR       {}
@@ -162,7 +162,7 @@ SOFTWARE.
   #define TWIR_CHK_ERROR(x)     (true)
   #define TWIR_SET_ERROR(x)     {}
 
-  //#define TWI_SET_EXT_ERROR(x)  {}
+  // #define TWI_SET_EXT_ERROR(x)  {}
 #endif
 
 

--- a/megaavr/libraries/Wire/src/twi.h
+++ b/megaavr/libraries/Wire/src/twi.h
@@ -98,7 +98,6 @@ SOFTWARE.
     #define BUFFER_LENGTH 32
   #else
     #define BUFFER_LENGTH 130
-    #define BUFFER_NOT_POWER_2
   #endif
 #endif
 
@@ -116,7 +115,7 @@ SOFTWARE.
 #define  TWI_ERR_UNDEFINED       0x04  // Software can't tell error source
 #define  TWI_ERR_TIMEOUT         0x05  // TWI Timed out on data rx/tx
 
-// Errors that are made to help finding errors on TWI lines. Only here to give a suggestion of where to look - these may not always be repoted accuratey.
+// Errors that are made to help finding errors on TWI lines. Only here to give a suggestion of where to look - these may not always be reported accurately.
 #if !defined(DISABLE_NEW_ERRORS)
   #define  TWI_ERR_UNINIT        0x10  // TWI was in bad state when function was called.
   #define  TWI_ERR_PULLUP        0x11  // Likely problem with pull-ups
@@ -188,18 +187,18 @@ struct twiData {
   #endif
   uint8_t _clientAddress;
   #if defined(TWI_MERGE_BUFFERS)
-    uint8_t _trHead;
-    uint8_t _trTail;
+    uint8_t _bytesToReadWrite;
+    uint8_t _bytesReadWritten;
   #else
-    uint8_t _txHead;
-    uint8_t _txTail;
-    uint8_t _rxHead;
-    uint8_t _rxTail;
+    uint8_t _bytesToWrite;
+    uint8_t _bytesToRead;
+    uint8_t _bytesRead;     // Used in slave mode exclusively
+    uint8_t _bytesWritten;  // Used in slave mode exclusively
   #endif
   #if defined(TWI_MANDS)
     uint8_t _incomingAddress;
-    uint8_t _trHeadS;
-    uint8_t _trTailS;
+    uint8_t _bytesToReadWriteS;
+    uint8_t _bytesReadWrittenS;
   #endif
   void (*user_onRequest)(void);
   void (*user_onReceive)(int);
@@ -212,7 +211,6 @@ struct twiData {
   #if defined(TWI_MANDS)
     uint8_t _trBufferS[BUFFER_LENGTH];
   #endif
-  uint8_t _slaveBytesRead;
 };
 
 
@@ -222,7 +220,6 @@ void     TWI_Flush(struct           twiData *_data);
 void     TWI_Disable(struct         twiData *_data);
 void     TWI_DisableMaster(struct   twiData *_data);
 void     TWI_DisableSlave(struct    twiData *_data);
-uint8_t  TWI_Available(struct       twiData *_data);
 void     TWI_HandleSlaveIRQ(struct  twiData *_data);
 uint8_t  TWI_MasterWrite(struct     twiData *_data, bool send_stop);
 void     TWI_MasterSetBaud(struct   twiData *_data, uint32_t frequency);


### PR DESCRIPTION
So, the thread in (https://github.com/SpenceKonde/megaTinyCore/issues/593) made me realize what the problem was (I've written an example at the end), so I've rewritten the buffer handling so that it is using linear buffers again. tbh, I don't even remember anymore, why I tried to use Ringbuffers. Anyway, Right now I'm not finished testing it and I haven't linted it yet, but I still wanted to open the Pull Request so you know that I've made some changes and to get a lint. With the abolishing of ringbuffers, I was able to save some more space I think and the buffer can be any of any size, it is not limited to the power of two.
Oh and I think I've spotted a bug in Master Read that would have blocked any Address sending if the TWI was already 'owned', for example by passing false instead of true to endTransmission()