### PR TITLE
Update python upload file parameters to handle paths with spaces

### DIFF
--- a/megaavr/boards.txt
+++ b/megaavr/boards.txt
@@ -1613,7 +1613,7 @@ avrdaopti.bootloader.SYSCFG0=0b1100{bootloader.resetpinbits}00
 avrdaopti.bootloader.CODESIZE=0x00
 avrdaopti.bootloader.BOOTSIZE=0x01
 avrdaopti.bootloader.avrdudestring=-Uflash:w:{bootloader.file}:i
-avrdaopti.bootloader.pymcuprogstring=-f{bootloader.file} -a write
+avrdaopti.bootloader.pymcuprogstring=-f "{bootloader.file}" -a write
 
 #----------------------------------------#
 # Upload parameters for Optiboot         #
@@ -1997,7 +1997,7 @@ avrdbopti.bootloader.SYSCFG1=0b000{bootloader.mviobits}{bootloader.sutbits}
 avrdbopti.bootloader.CODESIZE=0x00
 avrdbopti.bootloader.BOOTSIZE=0x01
 avrdbopti.bootloader.avrdudestring=-Uflash:w:{bootloader.file}:i
-avrdbopti.bootloader.pymcuprogstring=-f{bootloader.file} -a write
+avrdbopti.bootloader.pymcuprogstring=-f "{bootloader.file}" -a write
 
 #----------------------------------------#
 # Upload parameters for Optiboot         #
@@ -2433,7 +2433,7 @@ avrddopti.bootloader.SYSCFG1=0b00001{bootloader.sutbits}
 avrddopti.bootloader.CODESIZE=0x00
 avrddopti.bootloader.BOOTSIZE=0x01
 avrddopti.bootloader.avrdudestring=-Uflash:w:{bootloader.file}:i
-avrddopti.bootloader.pymcuprogstring=-f{bootloader.file} -a write
+avrddopti.bootloader.pymcuprogstring=-f "{bootloader.file}" -a write
 
 #----------------------------------------#
 # Upload parameters for Optiboot         #
@@ -2931,7 +2931,7 @@ azduinoboard.build.printf=
 #________________________________________#
 azduinoboard.bootloader.file={runtime.platform.path}/bootloaders/hex/{bootloader.class}_ser0_alt.hex
 azduinoboard.bootloader.avrdudestring=-Uflash:w:{bootloader.file}:i
-azduinoboard.bootloader.pymcuprogstring=-f{bootloader.file} -a write
+azduinoboard.bootloader.pymcuprogstring=-f "{bootloader.file}" -a write
 azduinoboard.bootloader.tool=avrdude
 azduinoboard.bootloader.WDTCFG=0x00
 azduinoboard.bootloader.BODCFG=0b{bootloader.bodlevbits}{bootloader.bodmodebits}

--- a/megaavr/platform.txt
+++ b/megaavr/platform.txt
@@ -231,4 +231,4 @@ tools.serialupdi.bootloader.pattern="{cmd}" -u "{runtime.platform.path}/tools/pr
 # Upload/Program will set fuses 5-8. Fuse 0 is not written because the core never configures that, and if a user went and set that themselvesm we shouldn't undo it.
 # Fuse 1 is the BOD configuration , which could "brick" the chip if set for a higher voltage than the power rail.
 # That leaves the two SYSCFG fuses which are safe (SYSCFG0 will not be safe on DD, though!), and the boot and codesize fuses.
-tools.serialupdi.program.pattern={upload.prog_interlock}"{cmd}" -u "{runtime.platform.path}/tools/prog.py" -t {protocol} {program.extra_params} -d {build.mcu} --fuses 5:{bootloader.SYSCFG0} 6:{bootloader.SYSCFG1} 7:{bootloader.CODESIZE} 8:{bootloader.BOOTSIZE} "-f{build.path}/{build.project_name}.hex" -a write {program.verbose}
+tools.serialupdi.program.pattern={upload.prog_interlock}"{cmd}" -u "{runtime.platform.path}/tools/prog.py" -t {protocol} {program.extra_params} -d {build.mcu} --fuses 5:{bootloader.SYSCFG0} 6:{bootloader.SYSCFG1} 7:{bootloader.CODESIZE} 8:{bootloader.BOOTSIZE} -f "{build.path}/{build.project_name}.hex" -a write {program.verbose}


### PR DESCRIPTION
Updated the various file parameters for the uploader so they can handle paths that include spaces or other special characters. This especially affects burning optiboot bootloaders over UPDI if the current user's username has a space in it.