### PR TITLE
dd spi pinmux correction

### DIFF
--- a/megaavr/variants/14pin-ddseries/pins_arduino.h
+++ b/megaavr/variants/14pin-ddseries/pins_arduino.h
@@ -126,15 +126,15 @@ Include guard and include basic libraries. We are normally including this inside
 // defining SPI_MUX_PINSWAP_n is how we signal to SPI.h that a given option is valid.
 // SPI 0
 
-#define SPI_MUX_PINSWAP_3      PORTMUX_SPI0_ALT3_gc
+
 #define SPI_MUX_PINSWAP_4      PORTMUX_SPI0_ALT4_gc
 #define SPI_MUX_PINSWAP_5      PORTMUX_SPI0_ALT5_gc
 #define SPI_MUX_PINSWAP_6      PORTMUX_SPI0_ALT6_gc
 #define SPI_MUX_PINSWAP_NONE   PORTMUX_SPI0_NONE_gc
-#define PIN_SPI_MOSI_PINSWAP_3 PIN_PA0
-#define PIN_SPI_MISO_PINSWAP_3 PIN_PA1
-#define PIN_SPI_SCK_PINSWAP_3  NOT_A_PIN // "What use is that?!" you say? The clock could be recovered from event channel or via a CCL and output on a pin. Master only though, ofc.
-#define PIN_SPI_SS_PINSWAP_3   PIN_PC1
+#define PIN_SPI_MOSI           NOT_A_PIN
+#define PIN_SPI_MISO           NOT_A_PIN
+#define PIN_SPI_SCK            NOT_A_PIN
+#define PIN_SPI_SS             NOT_A_PIN
 #define PIN_SPI_MOSI_PINSWAP_4 PIN_PD4
 #define PIN_SPI_MISO_PINSWAP_4 PIN_PD5
 #define PIN_SPI_SCK_PINSWAP_4  PIN_PD6
@@ -146,7 +146,7 @@ Include guard and include basic libraries. We are normally including this inside
 #define PIN_SPI_MOSI_PINSWAP_6 PIN_PC1
 #define PIN_SPI_MISO_PINSWAP_6 PIN_PC2
 #define PIN_SPI_SCK_PINSWAP_6  PIN_PC3
-#define PIN_SPI_SS_PINSWAP_6   NOT_A_PIN
+#define PIN_SPI_SS_PINSWAP_6   PIN_PF7 //(UPDI)
 
 
 // TWI 0

--- a/megaavr/variants/20pin-ddseries/pins_arduino.h
+++ b/megaavr/variants/20pin-ddseries/pins_arduino.h
@@ -130,7 +130,6 @@ Include guard and include basic libraries. We are normally including this inside
 
 // SPI 0
 #define SPI_MUX                         PORTMUX_SPI0_DEFAULT_g
-#define SPI_MUX_PINSWAP_3               PORTMUX_SPI0_ALT3_gc
 #define SPI_MUX_PINSWAP_4               PORTMUX_SPI0_ALT4_gc
 #define SPI_MUX_PINSWAP_5               PORTMUX_SPI0_ALT5_gc
 #define SPI_MUX_PINSWAP_6               PORTMUX_SPI0_ALT6_gc
@@ -139,10 +138,6 @@ Include guard and include basic libraries. We are normally including this inside
 #define PIN_SPI_MISO                    PIN_PA5
 #define PIN_SPI_SCK                     PIN_PA6
 #define PIN_SPI_SS                      PIN_PA7
-#define PIN_SPI_MOSI_PINSWAP_3          PIN_PA0
-#define PIN_SPI_MISO_PINSWAP_3          PIN_PA1
-#define PIN_SPI_SCK_PINSWAP_3           PIN_PC0
-#define PIN_SPI_SS_PINSWAP_3            PIN_PC1
 #define PIN_SPI_MOSI_PINSWAP_4          PIN_PD4
 #define PIN_SPI_MISO_PINSWAP_4          PIN_PD5
 #define PIN_SPI_SCK_PINSWAP_4           PIN_PD6
@@ -154,7 +149,7 @@ Include guard and include basic libraries. We are normally including this inside
 #define PIN_SPI_MOSI_PINSWAP_6          PIN_PC1
 #define PIN_SPI_MISO_PINSWAP_6          PIN_PC2
 #define PIN_SPI_SCK_PINSWAP_6           PIN_PC3
-#define PIN_SPI_SS_PINSWAP_6            NOT_A_PIN
+#define PIN_SPI_SS_PINSWAP_6            PIN_PF7 //(UPDI)
 
 // TWI 0
 #define PIN_WIRE_SDA                    PIN_PA2

--- a/megaavr/variants/28pin-ddseries/pins_arduino.h
+++ b/megaavr/variants/28pin-ddseries/pins_arduino.h
@@ -175,7 +175,7 @@ Include guard and include basic libraries. We are normally including this inside
 #define PIN_SPI_MOSI_PINSWAP_6          PIN_PC1
 #define PIN_SPI_MISO_PINSWAP_6          PIN_PC2
 #define PIN_SPI_SCK_PINSWAP_6           PIN_PC3
-#define PIN_SPI_SS_PINSWAP_6            NOT_A_PIN
+#define PIN_SPI_SS_PINSWAP_6            PIN_PF7 //(UPDI)
 
 
 // TWI 0


### PR DESCRIPTION
the SPI pinswap defines are inconsistent with DS40002413A-page 155:

pinswap 0x03 is reserved on 14-pin and 20-pin parts. its pins (A0,A1) do not occur in the table. They must have been copied from the 28/32 pin where they are correct.

and PIN_SPI_SS_PINSWAP_6 should be PIN_PF7 (UPDI) not NOT_A_PIN - or does defining it as NOT_A_PIN behave better with UPDI not fused to GPIO? In which case perhaps a comment (assuming an #ifdef against whatever drives that fuse option is impossible). But the 32-pin part already had PF7 so putting it in the other 3.

I added the defaults for PIN_SPI_X to NOT_A_PIN for consistency with TWI0, below where they were missing.

Head of tree is broken for me, thus this is completely untested (ran across it when I noticed a discrepancy between the mappings generated from parsing pins_arduino and the datasheet extracted pinmap).