### PR TITLE
fix issue 321 - SPI1 pins_arduino wrong for 28 (and 32) pin variant

### DIFF
--- a/megaavr/variants/28pin-standard/pins_arduino.h
+++ b/megaavr/variants/28pin-standard/pins_arduino.h
@@ -149,9 +149,9 @@ Include guard and include basic libraries. We are normally including this inside
 
 // SPI 1
 #define SPI1_MUX                PORTMUX_SPI1_DEFAULT_gc
-#define PIN_SPI1_MISO           PIN_PC0
-#define PIN_SPI1_SCK            PIN_PC1
-#define PIN_SPI1_MOSI           PIN_PC2
+#define PIN_SPI1_MOSI           PIN_PC0
+#define PIN_SPI1_MISO           PIN_PC1
+#define PIN_SPI1_SCK            PIN_PC2
 #define PIN_SPI1_SS             PIN_PC3
 
 // TWI 0

--- a/megaavr/variants/32pin-standard/pins_arduino.h
+++ b/megaavr/variants/32pin-standard/pins_arduino.h
@@ -156,9 +156,9 @@ Include guard and include basic libraries. We are normally including this inside
 
 // SPI 1
 #define SPI1_MUX                        PORTMUX_SPI1_DEFAULT_gc
-#define PIN_SPI1_MISO                   PIN_PC0
-#define PIN_SPI1_SCK                    PIN_PC1
-#define PIN_SPI1_MOSI                   PIN_PC2
+#define PIN_SPI1_MOSI                   PIN_PC0
+#define PIN_SPI1_MISO                   PIN_PC1
+#define PIN_SPI1_SCK                    PIN_PC2
 #define PIN_SPI1_SS                     PIN_PC3
 
 // TWI 0


### PR DESCRIPTION
the signals were out of order.  I verified that the 48 and 64 variants were correct. new values from page 163 of https://ww1.microchip.com/downloads/aemDocuments/documents/MCU08/ProductDocuments/DataSheets/AVR128DB28-32-48-64-DataSheet-DS40002247A.pdf