### PR TITLE
work around panic: no major version found in arduino 1.8.14+

### DIFF
--- a/megaavr/platform.txt
+++ b/megaavr/platform.txt
@@ -11,7 +11,7 @@ versionnum.patch=0
 versionnum.postfix=
 versionnum.released=0
 
-version={versionnum.major}.{versionnum.minor}.{versionnum.patch}{versionnum.postfix}
+version=1.5.0
 
 build.versiondefines=-DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} -DMEGATINYCORE="{version}" -DMEGATINYCORE_MAJOR={versionnum.major}UL -DMEGATINYCORE_MINOR={versionnum.minor}UL -DMEGATINYCORE_PATCH={versionnum.patch}UL -DMEGATINYCORE_RELEASED={versionnum.released}
 


### PR DESCRIPTION
this is a know bug with a trivial workaround that would get rid of the need to recommend against 1.8.19. I suspect the ratio of frustration saved to the indignity of workarounds to known bugs probably is justified in this case.