### PR TITLE
fix spaces that should be tabs in optiboot_dx makefile

### DIFF
--- a/megaavr/bootloaders/optiboot_dx/Makefile
+++ b/megaavr/bootloaders/optiboot_dx/Makefile
@@ -104,7 +104,7 @@ endif
 
 # If we have a PACKS directory specified, we should use it...
 ifdef PACKS
-PACK_OPT= -I $(PACKS)/include/ -B $(PACKS)/gcc/dev/$*
+PACK_OPT= -I $(PACKS)/include/ -B $(PACKS)/gcc/dev/$(TARGET)/
 ifndef PRODUCTION
 $(info   and Chip-defining PACKS at ${PACKS})
 endif
@@ -156,12 +156,12 @@ endif
 HELPTEXT += "\n-------------\n\n"
 
 optiboot_%.hex: optiboot_%.elf
-  $(OBJCOPY) -j .text -j .data -j .version -j .spmtarg --set-section-flags .version=alloc,load --set-section-flags .spmtarg=alloc,load -O ihex $< $@
+	$(OBJCOPY) -j .text -j .data -j .version -j .spmtarg --set-section-flags .version=alloc,load --set-section-flags .spmtarg=alloc,load -O ihex $< $@
 
 optiboot_%.elf:	optiboot_dx.c FORCE
-  $(CC) $(CFLAGS) $(CPU_OPTIONS) $(LED_OPTIONS) $(UART_OPTIONS) $(POR_CMD) $(COMMON_OPTIONS) $(LDFLAGS) $(PACK_OPT) -mmcu=$(TARGET) -o $@ $<
-  $(SIZE) $@
-  $(LISTING) $@ > optiboot_$*.lst
+	$(CC) $(CFLAGS) $(CPU_OPTIONS) $(LED_OPTIONS) $(UART_OPTIONS) $(POR_CMD) $(COMMON_OPTIONS) $(LDFLAGS) $(PACK_OPT) -mmcu=$(TARGET) -o $@ $<
+	$(SIZE) $@
+	$(LISTING) $@ > optiboot_$*.lst
 
 
 #---------------------------------------------------------------------------
@@ -175,471 +175,465 @@ optiboot_%.elf:	optiboot_dx.c FORCE
 
 dx128_ser0: TARGET = avr128da64
 dx128_ser0:
-  $(MAKE) -f $(MF) optiboot_dx128_ser0.hex UARTTX=A0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx128_ser0.hex UARTTX=A0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART0 default pins.\n"
 
 
 dx128_ser0_alt: TARGET = avr128da64
 dx128_ser0_alt:
-  $(MAKE) -f $(MF) optiboot_dx128_ser0_alt.hex UARTTX=A4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx128_ser0_alt.hex UARTTX=A4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART0 alternate pins.\n"
 
 
 dx128_ser1: TARGET = avr128da64
 dx128_ser1:
-  $(MAKE) -f $(MF) optiboot_dx128_ser1.hex UARTTX=C0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx128_ser1.hex UARTTX=C0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART1 default pins.\n"
 
 
 dx128_ser1_alt: TARGET = avr128da64
 dx128_ser1_alt:
-  $(MAKE) -f $(MF) optiboot_dx128_ser1_alt.hex UARTTX=C4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx128_ser1_alt.hex UARTTX=C4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART1 alternate pins.\n"
 
 
 dx128_ser2: TARGET = avr128da64
 dx128_ser2:
-  $(MAKE) -f $(MF) optiboot_dx128_ser2.hex UARTTX=F0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx128_ser2.hex UARTTX=F0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART2 default pins.\n"
 
 
 dx128_ser2_alt: TARGET = avr128da64
 dx128_ser2_alt:
-  $(MAKE) -f $(MF) optiboot_dx128_ser2_alt.hex UARTTX=F4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx128_ser2_alt.hex UARTTX=F4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART2 alternate pins.\n"
 
 
 dx128_ser3: TARGET = avr128da64
 dx128_ser3:
-  $(MAKE) -f $(MF) optiboot_dx128_ser3.hex UARTTX=B0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx128_ser3.hex UARTTX=B0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART3 default pins.\n"
 
 
 dx128_ser3_alt: TARGET = avr128da64
 dx128_ser3_alt:
-  $(MAKE) -f $(MF) optiboot_dx128_ser3_alt.hex UARTTX=B4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx128_ser3_alt.hex UARTTX=B4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART3 alternate pins.\n"
 
 
 dx128_ser4: TARGET = avr128da64
 dx128_ser4:
-  $(MAKE) -f $(MF) optiboot_dx128_ser4.hex UARTTX=E0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx128_ser4.hex UARTTX=E0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART4 default pins.\n"
 
 
 dx128_ser4_alt: TARGET = avr128da64
 dx128_ser4_alt:
-  $(MAKE) -f $(MF) optiboot_dx128_ser4_alt.hex UARTTX=E4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx128_ser4_alt.hex UARTTX=E4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART4 alternate pins.\n"
 
 
 dx128_ser5: TARGET = avr128da64
 dx128_ser5:
-  $(MAKE) -f $(MF) optiboot_dx128_ser5.hex UARTTX=G0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx128_ser5.hex UARTTX=G0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART5 default pins.\n"
 
 
 dx128_ser5_alt: TARGET = avr128da64
 dx128_ser5_alt:
-  $(MAKE) -f $(MF) optiboot_dx128_ser5_alt.hex UARTTX=G4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx128_ser5_alt.hex UARTTX=G4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART5 alternate pins.\n"
 
 dx64_ser0: TARGET = avr64da64
 dx64_ser0:
-  $(MAKE) -f $(MF) optiboot_dx64_ser0.hex UARTTX=A0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx64_ser0.hex UARTTX=A0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART0 default pins.\n"
 
 
 dx64_ser0_alt: TARGET = avr64da64
 dx64_ser0_alt:
-  $(MAKE) -f $(MF) optiboot_dx64_ser0_alt.hex UARTTX=A4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx64_ser0_alt.hex UARTTX=A4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART0 alternate pins.\n"
 
 
 dx64_ser1: TARGET = avr64da64
 dx64_ser1:
-  $(MAKE) -f $(MF) optiboot_dx64_ser1.hex UARTTX=C0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx64_ser1.hex UARTTX=C0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART1 default pins.\n"
 
 
 dx64_ser1_alt: TARGET = avr64da64
 dx64_ser1_alt:
-  $(MAKE) -f $(MF) optiboot_dx64_ser1_alt.hex UARTTX=C4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx64_ser1_alt.hex UARTTX=C4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART1 alternate pins.\n"
 
 
 dx64_ser2: TARGET = avr64da64
 dx64_ser2:
-  $(MAKE) -f $(MF) optiboot_dx64_ser2.hex UARTTX=F0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx64_ser2.hex UARTTX=F0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART2 default pins.\n"
 
 
 dx64_ser2_alt: TARGET = avr64da64
 dx64_ser2_alt:
-  $(MAKE) -f $(MF) optiboot_dx64_ser2_alt.hex UARTTX=F4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx64_ser2_alt.hex UARTTX=F4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART2 alternate pins.\n"
 
 
 dx64_ser3: TARGET = avr64da64
 dx64_ser3:
-  $(MAKE) -f $(MF) optiboot_dx64_ser3.hex UARTTX=B0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx64_ser3.hex UARTTX=B0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART3 default pins.\n"
 
 
 dx64_ser3_alt: TARGET = avr64da64
 dx64_ser3_alt:
-  $(MAKE) -f $(MF) optiboot_dx64_ser3_alt.hex UARTTX=B4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx64_ser3_alt.hex UARTTX=B4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART3 alternate pins.\n"
 
 
 dx64_ser4: TARGET = avr64da64
 dx64_ser4:
-  $(MAKE) -f $(MF) optiboot_dx64_ser4.hex UARTTX=E0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx64_ser4.hex UARTTX=E0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART4 default pins.\n"
 
 
 dx64_ser4_alt: TARGET = avr64da64
 dx64_ser4_alt:
-  $(MAKE) -f $(MF) optiboot_dx64_ser4_alt.hex UARTTX=E4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx64_ser4_alt.hex UARTTX=E4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART4 alternate pins.\n"
 
 
 dx64_ser5: TARGET = avr64da64
 dx64_ser5:
-  $(MAKE) -f $(MF) optiboot_dx64_ser5.hex UARTTX=G0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx64_ser5.hex UARTTX=G0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART5 default pins.\n"
 
 
 dx64_ser5_alt: TARGET = avr64da64
 dx64_ser5_alt:
-  $(MAKE) -f $(MF) optiboot_dx64_ser5_alt.hex UARTTX=G4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx64_ser5_alt.hex UARTTX=G4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART5 alternate pins.\n"
 
 dx32_ser0: TARGET = avr32da48
 dx32_ser0:
-  $(MAKE) -f $(MF) optiboot_dx32_ser0.hex UARTTX=A0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx32_ser0.hex UARTTX=A0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART0 default pins.\n"
 
 
 dx32_ser0_alt: TARGET = avr32da48
 dx32_ser0_alt:
-  $(MAKE) -f $(MF) optiboot_dx32_ser0_alt.hex UARTTX=A4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx32_ser0_alt.hex UARTTX=A4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART0 alternate pins.\n"
 
 
 dx32_ser1: TARGET = avr32da48
 dx32_ser1:
-  $(MAKE) -f $(MF) optiboot_dx32_ser1.hex UARTTX=C0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx32_ser1.hex UARTTX=C0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART1 default pins.\n"
 
 
 dx32_ser1_alt: TARGET = avr32da48
 dx32_ser1_alt:
-  $(MAKE) -f $(MF) optiboot_dx32_ser1_alt.hex UARTTX=C4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx32_ser1_alt.hex UARTTX=C4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART1 alternate pins.\n"
 
 
 dx32_ser2: TARGET = avr32da48
 dx32_ser2:
-  $(MAKE) -f $(MF) optiboot_dx32_ser2.hex UARTTX=F0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx32_ser2.hex UARTTX=F0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART2 default pins.\n"
 
 
 dx32_ser2_alt: TARGET = avr32da48
 dx32_ser2_alt:
-  $(MAKE) -f $(MF) optiboot_dx32_ser2_alt.hex UARTTX=F4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx32_ser2_alt.hex UARTTX=F4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART2 alternate pins.\n"
 
 
 dx32_ser3: TARGET = avr32da48
 dx32_ser3:
-  $(MAKE) -f $(MF) optiboot_dx32_ser3.hex UARTTX=B0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx32_ser3.hex UARTTX=B0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART3 default pins.\n"
 
 
 dx32_ser3_alt: TARGET = avr32da48
 dx32_ser3_alt:
-  $(MAKE) -f $(MF) optiboot_dx32_ser3_alt.hex UARTTX=B4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx32_ser3_alt.hex UARTTX=B4 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART3 alternate pins.\n"
 
 
 dx32_ser4: TARGET = avr32da48
 dx32_ser4:
-  $(MAKE) -f $(MF) optiboot_dx32_ser4.hex UARTTX=E0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
+	$(MAKE) -f $(MF) optiboot_dx32_ser4.hex UARTTX=E0 TIMEOUT=1 LED=A7 START_APP_ON_POR=1
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART4 default pins.\n"
 
 dx128_ser0_8sec: TARGET = avr128da64
 dx128_ser0_8sec:
-  $(MAKE) -f $(MF) optiboot_dx128_ser0_8sec.hex UARTTX=A0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx128_ser0_8sec.hex UARTTX=A0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART0 default pins. 8 sec timeout for manual reset.\n"
 
 
 dx128_ser0_alt_8sec: TARGET = avr128da64
 dx128_ser0_alt_8sec:
-  $(MAKE) -f $(MF) optiboot_dx128_ser0_alt_8sec.hex UARTTX=A4 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx128_ser0_alt_8sec.hex UARTTX=A4 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART0 alternate pins. 8 sec timeout for manual reset.\n"
 
 
 dx128_ser1_8sec: TARGET = avr128da64
 dx128_ser1_8sec:
-  $(MAKE) -f $(MF) optiboot_dx128_ser1_8sec.hex UARTTX=C0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx128_ser1_8sec.hex UARTTX=C0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART1 default pins. 8 sec timeout for manual reset.\n"
 
 
 dx128_ser1_alt_8sec: TARGET = avr128da64
 dx128_ser1_alt_8sec:
-  $(MAKE) -f $(MF) optiboot_dx128_ser1_alt_8sec.hex UARTTX=C4 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx128_ser1_alt_8sec.hex UARTTX=C4 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART1 alternate pins. 8 sec timeout for manual reset.\n"
 
 
 dx128_ser2_8sec: TARGET = avr128da64
 dx128_ser2_8sec:
-  $(MAKE) -f $(MF) optiboot_dx128_ser2_8sec.hex UARTTX=F0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx128_ser2_8sec.hex UARTTX=F0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART2 default pins. 8 sec timeout for manual reset.\n"
 
 
 dx128_ser2_alt_8sec: TARGET = avr128da64
 dx128_ser2_alt_8sec:
-  $(MAKE) -f $(MF) optiboot_dx128_ser2_alt_8sec.hex UARTTX=F4 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx128_ser2_alt_8sec.hex UARTTX=F4 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART2 alternate pins. 8 sec timeout for manual reset.\n"
 
 
 dx128_ser3_8sec: TARGET = avr128da64
 dx128_ser3_8sec:
-  $(MAKE) -f $(MF) optiboot_dx128_ser3_8sec.hex UARTTX=B0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx128_ser3_8sec.hex UARTTX=B0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART3 default pins. 8 sec timeout for manual reset.\n"
 
 
 dx128_ser3_alt_8sec: TARGET = avr128da64
 dx128_ser3_alt_8sec:
-  $(MAKE) -f $(MF) optiboot_dx128_ser3_alt_8sec.hex UARTTX=B4 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx128_ser3_alt_8sec.hex UARTTX=B4 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART3 alternate pins. 8 sec timeout for manual reset.\n"
 
 
 dx128_ser4_8sec: TARGET = avr128da64
 dx128_ser4_8sec:
-  $(MAKE) -f $(MF) optiboot_dx128_ser4_8sec.hex UARTTX=E0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx128_ser4_8sec.hex UARTTX=E0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART4 default pins. 8 sec timeout for manual reset.\n"
 
 
 dx128_ser4_alt_8sec: TARGET = avr128da64
 dx128_ser4_alt_8sec:
-  $(MAKE) -f $(MF) optiboot_dx128_ser4_alt_8sec.hex UARTTX=E4 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx128_ser4_alt_8sec.hex UARTTX=E4 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART4 alternate pins. 8 sec timeout for manual reset.\n"
 
 
 dx128_ser5_8sec: TARGET = avr128da64
 dx128_ser5_8sec:
-  $(MAKE) -f $(MF) optiboot_dx128_ser5_8sec.hex UARTTX=G0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx128_ser5_8sec.hex UARTTX=G0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART5 default pins. 8 sec timeout for manual reset.\n"
 
 
 dx128_ser5_alt_8sec: TARGET = avr128da64
 dx128_ser5_alt_8sec:
-  $(MAKE) -f $(MF) optiboot_dx128_ser4_alt_8sec.hex UARTTX=G4 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx128_ser4_alt_8sec.hex UARTTX=G4 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 128Dx - any AVR128DA or AVR128DB device, USART5 alternate pins. 8 sec timeout for manual reset.\n"
 
 dx64_ser0_8sec: TARGET = avr64da64
 dx64_ser0_8sec:
-  $(MAKE) -f $(MF) optiboot_dx64_ser0_8sec.hex UARTTX=A0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx64_ser0_8sec.hex UARTTX=A0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART0 default pins. 8 sec timeout for manual reset.\n"
 
 
 dx64_ser0_alt_8sec: TARGET = avr64da64
 dx64_ser0_alt_8sec:
-  $(MAKE) -f $(MF) optiboot_dx64_ser0_alt_8sec.hex UARTTX=A4 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx64_ser0_alt_8sec.hex UARTTX=A4 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART0 alternate pins. 8 sec timeout for manual reset.\n"
 
 
 dx64_ser1_8sec: TARGET = avr64da64
 dx64_ser1_8sec:
-  $(MAKE) -f $(MF) optiboot_dx64_ser1_8sec.hex UARTTX=C0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx64_ser1_8sec.hex UARTTX=C0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART1 default pins. 8 sec timeout for manual reset.\n"
 
 
 dx64_ser1_alt_8sec: TARGET = avr64da64
 dx64_ser1_alt_8sec:
-  $(MAKE) -f $(MF) optiboot_dx64_ser1_alt_8sec.hex UARTTX=C4 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx64_ser1_alt_8sec.hex UARTTX=C4 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART1 alternate pins. 8 sec timeout for manual reset.\n"
 
 
 dx64_ser2_8sec: TARGET = avr64da64
 dx64_ser2_8sec:
-  $(MAKE) -f $(MF) optiboot_dx64_ser2_8sec.hex UARTTX=F0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx64_ser2_8sec.hex UARTTX=F0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART2 default pins. 8 sec timeout for manual reset.\n"
 
 
 dx64_ser2_alt_8sec: TARGET = avr64da64
 dx64_ser2_alt_8sec:
-  $(MAKE) -f $(MF) optiboot_dx64_ser2_alt_8sec.hex UARTTX=F4 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx64_ser2_alt_8sec.hex UARTTX=F4 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART2 alternate pins. 8 sec timeout for manual reset.\n"
 
 
 dx64_ser3_8sec: TARGET = avr64da64
 dx64_ser3_8sec:
-  $(MAKE) -f $(MF) optiboot_dx64_ser3_8sec.hex UARTTX=B0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx64_ser3_8sec.hex UARTTX=B0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART3 default pins. 8 sec timeout for manual reset.\n"
 
 
 dx64_ser3_alt_8sec: TARGET = avr64da64
 dx64_ser3_alt_8sec:
-  $(MAKE) -f $(MF) optiboot_dx64_ser3_alt_8sec.hex UARTTX=B4 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx64_ser3_alt_8sec.hex UARTTX=B4 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART3 alternate pins. 8 sec timeout for manual reset.\n"
 
 
 dx64_ser4_8sec: TARGET = avr64da64
 dx64_ser4_8sec:
-  $(MAKE) -f $(MF) optiboot_dx64_ser4_8sec.hex UARTTX=E0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx64_ser4_8sec.hex UARTTX=E0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART4 default pins. 8 sec timeout for manual reset.\n"
 
 
 dx64_ser4_alt_8sec: TARGET = avr64da64
 dx64_ser4_alt_8sec:
-  $(MAKE) -f $(MF) optiboot_dx64_ser4_alt_8sec.hex UARTTX=E4 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx64_ser4_alt_8sec.hex UARTTX=E4 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART4 alternate pins. 8 sec timeout for manual reset.\n"
 
 
 dx64_ser5_8sec: TARGET = avr64da64
 dx64_ser5_8sec:
-  $(MAKE) -f $(MF) optiboot_dx64_ser5_8sec.hex UARTTX=G0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx64_ser5_8sec.hex UARTTX=G0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART5 default pins. 8 sec timeout for manual reset.\n"
 
 
 dx64_ser5_alt_8sec: TARGET = avr64da64
 dx64_ser5_alt_8sec:
-  $(MAKE) -f $(MF) optiboot_dx64_ser4_alt_8sec.hex UARTTX=G4 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx64_ser4_alt_8sec.hex UARTTX=G4 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 64Dx - any AVR64DA or AVR64DB device, USART5 alternate pins. 8 sec timeout for manual reset.\n"
 
 dx32_ser0_8sec: TARGET = avr32da48
 dx32_ser0_8sec:
-  $(MAKE) -f $(MF) optiboot_dx32_ser0_8sec.hex UARTTX=A0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx32_ser0_8sec.hex UARTTX=A0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART0 default pins. 8 sec timeout for manual reset.\n"
 
 
 dx32_ser0_alt_8sec: TARGET = avr32da48
 dx32_ser0_alt_8sec:
-  $(MAKE) -f $(MF) optiboot_dx32_ser0_alt_8sec.hex UARTTX=A4 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx32_ser0_alt_8sec.hex UARTTX=A4 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART0 alternate pins. 8 sec timeout for manual reset.\n"
 
 
 dx32_ser1_8sec: TARGET = avr32da48
 dx32_ser1_8sec:
-  $(MAKE) -f $(MF) optiboot_dx32_ser1_8sec.hex UARTTX=C0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx32_ser1_8sec.hex UARTTX=C0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART1 default pins. 8 sec timeout for manual reset.\n"
 
 
 dx32_ser1_alt_8sec: TARGET = avr32da48
 dx32_ser1_alt_8sec:
-  $(MAKE) -f $(MF) optiboot_dx32_ser1_alt_8sec.hex UARTTX=C4 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx32_ser1_alt_8sec.hex UARTTX=C4 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART1 alternate pins. 8 sec timeout for manual reset.\n"
 
 
 dx32_ser2_8sec: TARGET = avr32da48
 dx32_ser2_8sec:
-  $(MAKE) -f $(MF) optiboot_dx32_ser2_8sec.hex UARTTX=F0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx32_ser2_8sec.hex UARTTX=F0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART2 default pins. 8 sec timeout for manual reset.\n"
 
 
 dx32_ser2_alt_8sec: TARGET = avr32da48
 dx32_ser2_alt_8sec:
-  $(MAKE) -f $(MF) optiboot_dx32_ser2_alt_8sec.hex UARTTX=F4 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx32_ser2_alt_8sec.hex UARTTX=F4 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART2 alternate pins. 8 sec timeout for manual reset.\n"
 
 
 dx32_ser3_8sec: TARGET = avr32da48
 dx32_ser3_8sec:
-  $(MAKE) -f $(MF) optiboot_dx32_ser3_8sec.hex UARTTX=B0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx32_ser3_8sec.hex UARTTX=B0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART3 default pins. 8 sec timeout for manual reset.\n"
 
 
 dx32_ser3_alt_8sec: TARGET = avr32da48
 dx32_ser3_alt_8sec:
-  $(MAKE) -f $(MF) optiboot_dx32_ser3_alt_8sec.hex UARTTX=B4 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx32_ser3_alt_8sec.hex UARTTX=B4 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART3 alternate pins. 8 sec timeout for manual reset.\n"
 
 
 dx32_ser4_8sec: TARGET = avr32da48
 dx32_ser4_8sec:
-  $(MAKE) -f $(MF) optiboot_dx32_ser4_8sec.hex UARTTX=E0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx32_ser4_8sec.hex UARTTX=E0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART4 default pins. 8 sec timeout for manual reset.\n"
 
 dx32_ser0_alt2_8sec: TARGET = avr32dd32
 dx32_ser0_8sec:
-  $(MAKE) -f $(MF) optiboot_dx32_ser0_8sec.hex UARTTX=A0 TIMEOUT=8 LED=A7
+	$(MAKE) -f $(MF) optiboot_dx32_ser0_8sec.hex UARTTX=A0 TIMEOUT=8 LED=A7
 
 HELPTEXT += "target 32Dx - any AVR32DA or AVR32DB device, USART0 default pins. 8 sec timeout for manual reset.\n"
-
-
-
-/* PA2, PA3 */
-	  PORTMUX_USART0_ALT3_gc = (0x03<<0),  /* PD4, PD5, PD6, PD7 */
-	  PORTMUX_USART0_ALT4_gc = (0x04<<0),  /* PC1, PC2, PC3 */
 
 #---------------------------------------------------------------------------
 #
@@ -651,30 +645,30 @@ FORCE:
 # The build+upload functionality has not been tested and almost certainly doesn't work.
 
 isp: $(TARGET) FORCE
-  "$(MAKE)" -f Makefile.isp isp TARGET=$(TARGET)
+	"$(MAKE)" -f Makefile.isp isp TARGET=$(TARGET)
 
 isp-stk500: $(PROGRAM)_$(TARGET).hex
-  $(STK500-1)
-  $(STK500-2)
+	$(STK500-1)
+	$(STK500-2)
 
 #windows "rm" is dumb and objects to wildcards that don't exist
 clean:
-  @touch  __temp_.o __temp_.elf __temp_.lst __temp_.map
-  @touch  __temp_.sym __temp_.lss __temp_.eep __temp_.srec
-  @touch __temp_.bin __temp_.hex __temp_.tmp.sh
-  rm -rf *.o *.elf *.lst *.map *.sym *.lss *.eep *.srec *.bin *.hex *.tmp.sh
+	@touch  __temp_.o __temp_.elf __temp_.lst __temp_.map
+	@touch  __temp_.sym __temp_.lss __temp_.eep __temp_.srec
+	@touch __temp_.bin __temp_.hex __temp_.tmp.sh
+	rm -rf *.o *.elf *.lst *.map *.sym *.lss *.eep *.srec *.bin *.hex *.tmp.sh
 
 clean_asm:
-  rm -rf *.lst
+	rm -rf *.lst
 
 %.lst: %.elf FORCE
-  $(OBJDUMP) -h -S $< > $@
+	$(OBJDUMP) -h -S $< > $@
 
 %.srec: %.elf FORCE
-  $(OBJCOPY) -j .text -j .data -j .version --set-section-flags .version=alloc,load -O srec $< $@
+	$(OBJCOPY) -j .text -j .data -j .version --set-section-flags .version=alloc,load -O srec $< $@
 
 %.bin: %.elf FORCE
-  $(OBJCOPY) -j .text -j .data -j .version --set-section-flags .version=alloc,load -O binary $< $@
+	$(OBJCOPY) -j .text -j .data -j .version --set-section-flags .version=alloc,load -O binary $< $@
 
 help:
-  @echo -e $(HELPTEXT)
+	@echo -e $(HELPTEXT)


### PR DESCRIPTION
Some tabs were converted to spaces by an overzealous editor feature.
Makefiles need tabs, so this changes them back.
(also, this fixes PACKS support to be dependent on target CPU instead of makefile target.)