### PR TITLE
Critical: PORTC interrupt not being defined causing reset

### DIFF
--- a/megaavr/cores/dxcore/WInterrupts.c
+++ b/megaavr/cores/dxcore/WInterrupts.c
@@ -382,7 +382,7 @@
       __builtin_unreachable();
     }
     #endif
-    #ifdef PORTC_PINS
+    #ifdef PORTC
       ISR(PORTC_PORT_vect, ISR_NAKED) {
       asm volatile(
         "push r16"      "\n\t"
@@ -392,6 +392,9 @@
 #else
         "rjmp AttachedISR" "\n\t"
 #endif
+        ::);
+      __builtin_unreachable();
+    }
     #endif
     #ifdef PORTD
       ISR(PORTD_PORT_vect, ISR_NAKED){


### PR DESCRIPTION
Hello,

We discovered that something was wrong with the new interrupt system, specifically on PORTC. Turns out the ISR wasn't defined due to PORTC_PINS not being defined. This caused example code to crash when an interrupt on PORTC happened. This PR fixes the bug. 