### PR TITLE
Formatting check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # DxCore - Arduino support for the AVR DA, DB-series and DD-series
 
 ## 1.5. ~0~ ~1~ ~2~ ~3~ ~4~ ~5~ 6 is here
-DD support is in, and the sixth set of bugs that have been found in it are fixed. This really should have been caught much sooner: PWM was totally hosed! Wakey wakey people! These parts should be capable of nearly 30 simultaneous PWM duty cycles, not 3. Don't let me get away with releasing shit that's broken that badly! How did we get through five versions, where I specifically suggested that there might be bugs relating to PWM output... without anyone noticing this? But don't worry; there are several other critical bugs fixed here if you aren't using PWM. 
+DD support is in, and the sixth set of bugs that have been found in it are fixed. This really should have been caught much sooner: PWM was totally hosed! Wakey wakey people! These parts should be capable of nearly 30 simultaneous PWM duty cycles, not 3. Don't let me get away with releasing shit that's broken that badly! How did we get through five versions, where I specifically suggested that there might be bugs relating to PWM output... without anyone noticing this? But don't worry; there are several other critical bugs fixed here if you aren't using PWM.
 
 Please be on the lookout for *any further* bugs and regressions, ~particularly relating to the new parts and to PWM.~
 
-A major regression has been noted in PWM and DAC output (specifically, on many parts, there isn't any). Additionally, there appears to be undocumented errata on extant Dx-series parts....
+A major regression has been noted in PWM and DAC output (specifically, on many parts, there isn't any). Additionally, there appears to be undocumented errata on extant Dx-series parts...
 
 ## IMPORTANT WARNINGS
 

--- a/megaavr/libraries/DxCore/src/DxCore.h
+++ b/megaavr/libraries/DxCore/src/DxCore.h
@@ -26,7 +26,7 @@ typedef enum X32K_ENABLE {
 
 
 #ifndef __cplusplus
-  void configXOSC32K(X32K_OPT_t settings, X32K_ENABLE_t enable);
+void configXOSC32K(X32K_OPT_t settings, X32K_ENABLE_t enable);
 #endif
 // attempts to configure the external crystal or oscillator.
 // see above for valid values of these two arguments. This handles the enable-locking of many of these bits.
@@ -65,7 +65,7 @@ uint8_t getMVIOStatus();
 // Returns either MVIO_OKAY (0) or an error code, depending on the state of MVIO
 
 #ifndef __cplusplus
-  uint8_t initOPAMP_MVIO(uint16_t voltage, uint8_t opamp, uint8_t options, int16_t dacref);
+uint8_t initOPAMP_MVIO(uint16_t voltage, uint8_t opamp, uint8_t options, int16_t dacref);
 #endif
 
 // These are returned by either initOPAMP_MVIO or getMVIOStatus() and getMVIOVoltage().
@@ -107,16 +107,16 @@ Timer pin mux
  */
 
 #if defined(TCA0)
-  bool setTCA0MuxByPort(uint8_t port);
-  bool setTCA0MuxByPin(uint8_t pin);
+bool setTCA0MuxByPort(uint8_t port);
+bool setTCA0MuxByPin(uint8_t pin);
 #endif
 #if defined(TCA1)
-  bool setTCA1MuxByPort(uint8_t port);
-  bool setTCA1MuxByPin(uint8_t pin);
+bool setTCA1MuxByPort(uint8_t port);
+bool setTCA1MuxByPin(uint8_t pin);
 #endif // TCA1
 #if defined(TCD0)
-  bool setTCD0MuxByPort(uint8_t port);
-  bool setTCD0MuxByPin(uint8_t pin);
+bool setTCD0MuxByPort(uint8_t port);
+bool setTCD0MuxByPin(uint8_t pin);
 #endif
 int8_t timerToDigitalPin(uint8_t timer, uint8_t channel);
 
@@ -137,15 +137,15 @@ inline void ResetWithWDT() {
 
 // C++ prototypes. C-definitions are grouped above by function.
 #ifdef __cplusplus
-  }
-  uint8_t initOPAMP_MVIO(uint16_t voltage, uint8_t opamp = 0, uint8_t options = 0, int16_t dacref = -1);
-  void configXOSC32K(X32K_OPT_t = X32K_HIGHPWR_START2S, X32K_ENABLE_t = X32K_ENABLED);
+}
+uint8_t initOPAMP_MVIO(uint16_t voltage, uint8_t opamp = 0, uint8_t options = 0, int16_t dacref = -1);
+void configXOSC32K(X32K_OPT_t = X32K_HIGHPWR_START2S, X32K_ENABLE_t = X32K_ENABLED);
 // in ADCErrors.cpp
 // ADC error interpretation helper functions
-  int8_t analogCheckError(int16_t val);
-  int8_t analogCheckError(int32_t val);
-  bool printADCRuntimeError(int32_t error, HardwareSerial &__dbgser = Serial);
-  bool printADCRuntimeError(int16_t error, HardwareSerial &__dbgser = Serial);
+int8_t analogCheckError(int16_t val);
+int8_t analogCheckError(int32_t val);
+bool printADCRuntimeError(int32_t error, HardwareSerial &__dbgser = Serial);
+bool printADCRuntimeError(int16_t error, HardwareSerial &__dbgser = Serial);
 #endif
 
 


### PR DESCRIPTION
Fixed whitespace in README.md, fixed erroneous indentation after preprocessor directives in DxCore.h

Should again let all the bots be on their merry way for that sweet, sweet green checkmark.