### PR TITLE
Several check updates

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -48,6 +48,7 @@ jobs:
         - megaavr/libraries/Logic/examples/Five_input_NOR
         - megaavr/libraries/Logic/examples/Interrupt
         - megaavr/libraries/Logic/examples/LatchNoSeq
+        - megaavr/libraries/Logic/examples/LatchNoSeqDx14
         - megaavr/libraries/Logic/examples/Three_input_AND
         - megaavr/libraries/Logic/examples/Three_input_NAND
         - megaavr/libraries/Logic/examples/Three_input_OR

--- a/megaavr/libraries/Logic/examples/LatchNoSeqDx14/LatchNoSeqDx14.ino
+++ b/megaavr/libraries/Logic/examples/LatchNoSeqDx14/LatchNoSeqDx14.ino
@@ -45,7 +45,7 @@ void setup() {
   Event3.set_generator(PIN_PC3);
   Event3.set_user(user::ccl0_event_b);
   Event3.start();
-  
+
   Event4.set_generator(gen::ccl0_out);
   Event4.set_user(user::evoutc_pin_pc2);
   Event4.start();
@@ -58,7 +58,7 @@ void setup() {
   Logic0.truth = 0x8E;                    // Set truth table - HIGH only if both high
   Logic0.init();                          // Initialize logic block 0
   Logic::start();
-  
+
 }
 
 void loop() {

--- a/megaavr/libraries/Logic/examples/LatchNoSeqDx14/LatchNoSeqDx14.ino
+++ b/megaavr/libraries/Logic/examples/LatchNoSeqDx14/LatchNoSeqDx14.ino
@@ -4,7 +4,7 @@
 | Original Example by Spence Konde                                      |
 | Modified to use event system by Andrew J. Kroll                       |
 |                                                                       |
-| LatchNoSeqDD14.ino - Getting "RS Latch" like behavior with a single   |
+| LatchNoSeqDx14.ino - Getting "RS Latch" like behavior with a single   |
 | even numbered LUT. Should work on ALL parts.                          |
 |                                                                       |
 | In this example we use the configurable logic peripherals in AVR      |


### PR DESCRIPTION
This PR fixes the trailing whitespaces in the new example sketch, and also adds the new example sketch to the compile tests so that it too is covered by the compile checks if and when it is modified. Additionally it changes the header of that example sketch slightly so that the name of the sketch in the header matches that of the filename.