### PR TITLE
Update action checkout to v4

### DIFF
--- a/.github/workflows/arduino-lint.yml
+++ b/.github/workflows/arduino-lint.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # See: https://github.com/arduino/arduino-lint-action#readme
       - name: Arduino Lint

--- a/.github/workflows/check-code-formatting.yml
+++ b/.github/workflows/check-code-formatting.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check code formatting
         uses: per1234/artistic-style-action@main
@@ -67,7 +67,7 @@ jobs:
 
 #    steps:
 #      - name: Checkout
-#        uses: actions/checkout@v2
+#        uses: actions/checkout@v4
 
 #      - name: Check code formatting
 #        uses: per1234/artistic-style-action@main
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check code formatting
         uses: per1234/artistic-style-action@main
@@ -99,7 +99,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check code formatting
         uses: per1234/artistic-style-action@main

--- a/.github/workflows/check-keywords-txt.yml
+++ b/.github/workflows/check-keywords-txt.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install arduino-ci-script
         uses: per1234/install-arduino-ci-script-action@main

--- a/.github/workflows/check-library-properties.yml
+++ b/.github/workflows/check-library-properties.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install arduino-ci-script
         uses: per1234/install-arduino-ci-script-action@main

--- a/.github/workflows/check-library-structure.yml
+++ b/.github/workflows/check-library-structure.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install arduino-ci-script
         uses: per1234/install-arduino-ci-script-action@main

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check links
         uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -319,7 +319,7 @@ jobs:
           - device-family: du
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # See: https://github.com/arduino/compile-sketches/README.md
 

--- a/.github/workflows/general-formatting-checks.yml
+++ b/.github/workflows/general-formatting-checks.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check for UTF-8 BOM file encoding
         run: find . -path './.git' -prune -or -type f -exec grep --files-with-matches --binary-files=without-match $'\xEF\xBB\xBF' '{}' \; -exec echo 'UTF-8 BOM encoding detected.' \; -exec false '{}' +
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check for files starting with a blank line
         run: find . -path './.git' -prune -or \( -not -name '*.py' -and -not -name '*.log' -and -type f \) -print0 | xargs -0 -L1 bash -c 'head -1 "$0" | grep --binary-files=without-match --regexp="^$"; if [[ "$?" == "0" ]]; then echo "Blank line found at start of $0."; false; fi'
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check for unnecessary use of true tabs
         run: find . -path './.git' -prune -or \( -not -name 'keywords.txt' -and -not -name 'Makefile' -and -not -name '*.py' -and -not -name '*.log' -and -not -name '.gitmodules' -and -type f \) -exec grep --with-filename --line-number --binary-files=without-match --regexp=$'\t' '{}' \; -exec echo 'Tab found.' \; -exec false '{}' +
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check for trailing whitespace
         run: find . -path './.git' -prune -or \( -not -name '*.hex' -and -not -name '*.py' -and -not -name '*.log' -and -not -name '*.gif' -and -not -name '*.png' -and -type f \) -exec grep --with-filename --line-number --binary-files=without-match --regexp='[[:blank:]]$' '{}' \; -exec echo 'Trailing whitespace found.' \; -exec false '{}' +
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check for non-Unix line endings
         run: find . -path './.git' -prune -or \( -not -name '*.hex' -and -type f \) -exec grep --files-with-matches --binary-files=without-match --regexp=$'\r$' '{}' \; -exec echo 'Non-Unix EOL detected.' \; -exec false '{}' +
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check for blank lines at end of files
         run: find . -path './.git' -prune -or \( -not -name '*.py' -and -type f \) -print0 | xargs -0 -L1 bash -c 'tail -1 "$0" | grep --binary-files=without-match --regexp="^$"; if [[ "$?" == "0" ]]; then echo "Blank line found at end of $0."; false; fi'
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Check for files that don't end in a newline
         # https://stackoverflow.com/a/25686825
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # See: https://github.com/codespell-project/actions-codespell/blob/master/README.md
       - name: Spell check


### PR DESCRIPTION
This updates the checkout for Github Actions to v4 in order to avoid running into impending deprecation and failure of the actions.