### PR TITLE
Fix Uart D6 for AVRDD UART D6

### DIFF
--- a/megaavr/bootloaders/optiboot_dx/pin_defs_dx.h
+++ b/megaavr/bootloaders/optiboot_dx/pin_defs_dx.h
@@ -713,7 +713,7 @@
     #define MYUART_RXPINCTRL (PORTD.PIN7CTRL)
     #define MYUART_TXPORT VPORTD
     #define MYUART_TXPIN (1 << PORT6)
-    #define MYUART_PMUX_VAL (0x04)
+    #define MYUART_PMUX_VAL (2 << 3)
     #define MYPMUX_REG (PORTMUX.USARTROUTEA)
   #endif
 #endif
@@ -828,7 +828,7 @@
     #define MYUART_RXPINCTRL (PORTA.PIN7CTRL)
     #define MYUART_TXPORT VPORTD
     #define MYUART_TXPIN (1 << PORT6)
-    #define MYUART_PMUX_VAL (2 << 4)
+    #define MYUART_PMUX_VAL (2 << 3)
     #define MYPMUX_REG (PORTMUX.USARTROUTEA)
   #endif
 #endif


### PR DESCRIPTION
USART1 occupies bits [4:3] of PORTMUX.USARTROUTEA, so ALT2 (0x02) must be shifted left by 3, giving (2 << 3) = 0x10 Fix for 30/28 & 14 pin variants (20 pin correct)