### PR TITLE
Fix issue #608 in turnPWMoff(): make DAC output pin compatible with analog/digital Write()

### DIFF
--- a/megaavr/cores/dxcore/wiring_digital.c
+++ b/megaavr/cores/dxcore/wiring_digital.c
@@ -24,6 +24,7 @@
   megaTinyCore and DxCore.
 */
 
+#include "avr/io.h"
 #define ARDUINO_MAIN
 #include "wiring_private.h"
 #include "pins_arduino.h"
@@ -298,10 +299,13 @@ void turnOffPWM(uint8_t pin) {
         }
       }
     #endif
+
     #if defined(DAC0)
       if (digital_pin_timer == DACOUT) {
-        _setInput(portnum, bit_mask);
-        DAC0.CTRLA &= ~0x41; // clear we want to turn off the DAC in this case
+        if (DAC0.CTRLA & DAC_OUTEN_bm) {  // digitalWrite() to DAC Output: Disable DAC
+          DAC0.CTRLA &= ~0x41;            // clear we want to turn off the DAC in this case
+          _setOutput(portnum, bit_mask);  // enable pin as Output
+        }
       }
     #endif
   }

--- a/megaavr/cores/dxcore/wiring_digital.c
+++ b/megaavr/cores/dxcore/wiring_digital.c
@@ -24,7 +24,6 @@
   megaTinyCore and DxCore.
 */
 
-#include "avr/io.h"
 #define ARDUINO_MAIN
 #include "wiring_private.h"
 #include "pins_arduino.h"


### PR DESCRIPTION
analogWrite() to the DAC output pin will start the DAC and output the analog value directly, so PWM is not used.
On digitalWrite() to the DAC output pin, the turnPWMoff() function unconditionally switches off the DAC and sets the pin direction to input. Thus the pin is no longer an output, see issue https://github.com/SpenceKonde/DxCore/issues/608.
For the DAC output pin, the turnPWMoff() function must check if PWM is active and only then turn it off. This can be done by checking if the DAC is enabled. In this case the DAC is disabled and the pin direction must be set to output.
