### PR TITLE
Add missing serialupdi to table

### DIFF
--- a/PlatformIO.md
+++ b/PlatformIO.md
@@ -266,6 +266,7 @@ Programmer used for uploading.
 | `atmelice_updi`                       | Atmel ICE programmer in UPDI mode                                                                                |
 | `xplainedpro_updi`                    | Xplained Pro in UPDI mode                                                                                        |
 | `powerdebugger_updi`                  | Power Debugger in UPDI mode                                                                                      |
+| `serialupdi`                          | Simple programmer in UPDI mode                                                                                    |
 
 
 ### `upload_flags`


### PR DESCRIPTION
Using DxCore with Platformio will be easier if you show that "serialupdi" also can be used. I'm guessing that many will use this option and not a more professional programmer?