### PR TITLE
Fix three core/library bugs affecting all AVR

### DIFF
--- a/megaavr/cores/dxcore/wiring_analog.c
+++ b/megaavr/cores/dxcore/wiring_analog.c
@@ -418,7 +418,7 @@ inline __attribute__((always_inline)) void check_valid_resolution(uint8_t res) {
     #endif
       return ADC_ERROR_BAD_PIN_OR_CHANNEL;
     }
-    if (!ADC0.CTRLA & 0x01) return ADC_ERROR_DISABLED;
+    if (!(ADC0.CTRLA & 0x01)) return ADC_ERROR_DISABLED;
 
     if (ADC0.COMMAND & ADC_START_gm) return ADC_ERROR_BUSY;
     // gotta be careful here - don't want to shit ongoing conversion - unlikle classic AVRs
@@ -730,7 +730,7 @@ inline __attribute__((always_inline)) void check_valid_resolution(uint8_t res) {
     #endif
       return ADC_ERROR_BAD_PIN_OR_CHANNEL;
     }
-    if (!ADC0.CTRLA & 0x01) return ADC_ERROR_DISABLED;
+    if (!(ADC0.CTRLA & 0x01)) return ADC_ERROR_DISABLED;
 
     if (ADC0.COMMAND & ADC_START_gm) return ADC_ERROR_BUSY;
     // gotta be careful here - don't want to shit ongoing conversion - unlikle classic AVRs

--- a/megaavr/cores/dxcore/wiring_extra.cpp
+++ b/megaavr/cores/dxcore/wiring_extra.cpp
@@ -158,7 +158,7 @@ void pinConfigure(uint8_t digital_pin, uint16_t pin_config) {
   uint8_t _setEventPin(uint8_t pin, uint8_t chan) {
     // Works the same was as
     uint8_t temp = digitalPinToPort(pin);
-    if (temp != NOT_A_PIN && (chan + 1) < 3) {
+    if (temp != NOT_A_PIN && (chan == 255 || chan < 2)) { // (chan + 1) < 3 promoted to int, so chan = 255 could never take this path
       volatile uint8_t* p;
       p = (volatile uint8_t*) (uint16_t) (digitalPinToPortStruct(temp));
       p += 0x18; // now p pointing to evgenctrl.

--- a/megaavr/libraries/Flash/src/Flash.cpp
+++ b/megaavr/libraries/Flash/src/Flash.cpp
@@ -405,20 +405,28 @@ uint8_t FlashClass::writeWords(const uint32_t address, const uint16_t* data, uin
 
 uint8_t FlashClass::writeBytes(const uint32_t address, const uint8_t* data, uint16_t length) {
   uint32_t tAddress = address;
-  uint8_t status;
-  if(address & 0x01) {
-    status = writeByte(tAddress++, *(data));
+  uint8_t status = FLASHWRITE_OK;
+  if (length == 0) {
+    return FLASHWRITE_0LENGTH;
+  }
+  if (tAddress & 0x01) {
+    // Unaligned start: write the leading byte, then continue word-aligned.
+    status = writeByte(tAddress++, *data++);
     if (status) return status;
     length--;
   }
-  if(length > 1) {
-    status = writeWords(tAddress, (uint16_t*) data, (length >> 1));
+  if (length > 1) {
+    // The bulk of the data, as whole words.
+    uint16_t words = length >> 1;
+    status = writeWords(tAddress, (uint16_t*) data, words);
     if (status) return status;
+    tAddress += ((uint32_t) words) << 1;
+    data     += words << 1;
+    length   -= words << 1;   // 0 or 1 byte left
   }
-  // there may be one more byte...
   if (length & 1) {
-    data += (length & 0xFFFE); // what we wrote with the word above...
-    status = writeByte(tAddress + length - 2, *data);
+    // And finally the trailing byte, if the length was odd.
+    status = writeByte(tAddress, *data);
   }
   return status;
 }


### PR DESCRIPTION
Three small, unrelated bug fixes. 
None are part-specific - they affectcurrent master as-is.

**1. wiring_analog.c**
`if (!ADC0.CTRLA & 0x01)` evaluates as `(!ADC0.CTRLA) & 0x01`, so the "ADC disabled" early return never fired.
Parenthesized (both occurrences).

**2. wiring_extra.cpp**
`(chan + 1) < 3` promotes to int,
so the documented auto-select value `chan = 255` became `256 < 3` and could never take this path.
Compare explicitly.

**3. Flash.cpp / writeBytes**
on unaligned/odd-length requests the leading byte was written without advancing the data pointer (shifting the rest by one), 
state wasn't advanced after writeWords, and the trailing byte landed on the wrong address.
Rewritten to advance state explicitly at each stage; also returns FLASHWRITE_0LENGTH on zero length.

Verified to compile for AVR128DA48.
(core changes via a standard sketch; Flash via FlashDemo and a minimal writeBytes sketch, with "Write to flash from app" enabled)

These were found while working on AVR-DU support (#637).
with these fixes applied, everything runs fine on an AVR64DU32 on CuriosityNano.