### PR TITLE
Generic AVR DU board fixes: fuses, usable defaults, DU-correct core paths

### DIFF
--- a/megaavr/boards.txt
+++ b/megaavr/boards.txt
@@ -99,6 +99,7 @@ menu.mvio=MultiVoltage I/O (MVIO)
 menu.mvioopti=MultiVoltage I/O (MVIO)
 menu.attach=attachInterrupt() Version
 menu.printf=printf()
+menu.usbvreg=VUSB Power Source (AVR DU)
 menu.wiremode=Wire (Wire.h/I2C) Library mode
 menu.flmap=How to set FLMAP: (64k+ parts only)
 menu.bootloader-class=Bootloader type (installed by burn + must match 2 upload)
@@ -1707,7 +1708,7 @@ avrdu.upload.maximum_data_size=0
 avrdu.build.f_cpu={build.speed}000000L
 avrdu.build.text_section_start=.text=0x0
 avrdu.build.defaultswaps=
-avrdu.build.extra_flags= {bootloader.appspm} {build.defaultswaps}
+avrdu.build.extra_flags= {bootloader.appspm} {build.defaultswaps} {build.usbvreg}
 avrdu.build.export_merged_output=false
 # Every DU has exactly two TCBs (TCB0/TCB1) at every pin count, unlike the DD
 # where the 28/32-pin parts get a TCB2 - so highestcb is B1 for the whole
@@ -1744,6 +1745,15 @@ avrdu.menu.eesave.enable=EEPROM retained
 avrdu.menu.eesave.enable.bootloader.eesavebit=1
 avrdu.menu.eesave.disable=EEPROM not retained
 avrdu.menu.eesave.disable.bootloader.eesavebit=0
+
+# VUSB power source (SYSCFG.VUSBCTRL). The internal regulator resets to
+# disabled; the PC3 I/O buffer is in the VUSB domain, so even non-USB
+# sketches need VUSB powered to read PC3. Select "External" when the board
+# feeds 3.3 V into VUSB directly.
+avrdu.menu.usbvreg.internal=Internal regulator from VDD
+avrdu.menu.usbvreg.internal.build.usbvreg=-DUSB_VREG_INTERNAL
+avrdu.menu.usbvreg.external=External 3.3V supplied on VUSB
+avrdu.menu.usbvreg.external.build.usbvreg=
 
 #----------------------------------------#
 # Exported hex/lst/map names will        #

--- a/megaavr/boards.txt
+++ b/megaavr/boards.txt
@@ -1747,9 +1747,9 @@ avrdu.menu.eesave.disable=EEPROM not retained
 avrdu.menu.eesave.disable.bootloader.eesavebit=0
 
 # VUSB power source (SYSCFG.VUSBCTRL). The internal regulator resets to
-# disabled; the PC3 I/O buffer is in the VUSB domain, so even non-USB
-# sketches need VUSB powered to read PC3. Select "External" when the board
-# feeds 3.3 V into VUSB directly.
+# disabled; anything using the USB peripheral needs VUSB powered. Select
+# "External" when the board feeds 3.3 V into VUSB directly instead of
+# using the internal regulator.
 avrdu.menu.usbvreg.internal=Internal regulator from VDD
 avrdu.menu.usbvreg.internal.build.usbvreg=-DUSB_VREG_INTERNAL
 avrdu.menu.usbvreg.external=External 3.3V supplied on VUSB

--- a/megaavr/boards.txt
+++ b/megaavr/boards.txt
@@ -1709,7 +1709,10 @@ avrdu.build.text_section_start=.text=0x0
 avrdu.build.defaultswaps=
 avrdu.build.extra_flags= {bootloader.appspm} {build.defaultswaps}
 avrdu.build.export_merged_output=false
-avrdu.build.highestcb=B2
+# Every DU has exactly two TCBs (TCB0/TCB1) at every pin count, unlike the DD
+# where the 28/32-pin parts get a TCB2 - so highestcb is B1 for the whole
+# family and no chip needs to override it.
+avrdu.build.highestcb=B1
 avrdu.build.printf=
 avrdu.build.flmapopts=
 avrdu.build.attachmode=-DCORE_ATTACH_ALL
@@ -1763,7 +1766,7 @@ avrdu.menu.chip.avr64du32.build.mcu=avr64du32
 avrdu.menu.chip.avr64du32.upload.maximum_size=65536
 avrdu.menu.chip.avr64du32.upload.maximum_data_size=8192
 avrdu.menu.chip.avr64du32.build.variant=32pin-duseries
-avrdu.menu.chip.avr64du32.build.highestcb=B2
+avrdu.menu.chip.avr64du32.build.highestcb=B1
 avrdu.menu.chip.avr64du28.build.mcu=avr64du28
 avrdu.menu.chip.avr64du28.upload.maximum_size=65536
 avrdu.menu.chip.avr64du28.upload.maximum_data_size=8192

--- a/megaavr/boards.txt
+++ b/megaavr/boards.txt
@@ -1732,6 +1732,18 @@ avrdu.bootloader.CODESIZE=0x00
 avrdu.bootloader.BOOTSIZE=0x01
 avrdu.bootloader.avrdudestring=
 avrdu.bootloader.pymcuprogstring=-aerase
+# The SYSCFG0 template above expands {bootloader.resetpinbits} and
+# {bootloader.eesavebit}, but neither was defined for the DU section, and
+# fuse 5 (SYSCFG0) was never written. Add the missing pieces, matching the
+# DA/DB/DD sections.
+avrdu.bootloader.resetpinbits={bootloader.resetpinbit}
+avrdu.bootloader.avrdudefuse5="-Ufuse5:w:{bootloader.SYSCFG0}:m"
+avrdu.program.avrdudefuse5="-Ufuse5:w:{bootloader.SYSCFG0}:m"
+
+avrdu.menu.eesave.enable=EEPROM retained
+avrdu.menu.eesave.enable.bootloader.eesavebit=1
+avrdu.menu.eesave.disable=EEPROM not retained
+avrdu.menu.eesave.disable.bootloader.eesavebit=0
 
 #----------------------------------------#
 # Exported hex/lst/map names will        #

--- a/megaavr/cores/dxcore/wiring.c
+++ b/megaavr/cores/dxcore/wiring.c
@@ -1559,6 +1559,14 @@ void init() {
     // but due to a silicon bug, the input buffer is on, but it's input is floating. Per errata, we are supposed to turn it off.
     PORTD.PIN0CTRL = PORT_ISC_INPUT_DISABLE_gc;
   #endif
+  #if defined(USB_VREG_INTERNAL)
+    /* AVR DU: enable the internal USB voltage regulator (SYSCFG.VUSBCTRL).
+     * It resets to disabled, and the PC3 input buffer is in the VUSB power
+     * domain - so PC3 cannot be read until VUSB is powered, even if USB
+     * itself is never used. Controlled by the "VUSB Power Source" menu;
+     * boards feeding external 3.3 V into VUSB leave this macro undefined. */
+    SYSCFG.VUSBCTRL = SYSCFG_USBVREG_bm;
+  #endif
   init_clock();
   init_timers();
   #if defined(ADC0)

--- a/megaavr/cores/dxcore/wiring.c
+++ b/megaavr/cores/dxcore/wiring.c
@@ -1561,10 +1561,9 @@ void init() {
   #endif
   #if defined(USB_VREG_INTERNAL)
     /* AVR DU: enable the internal USB voltage regulator (SYSCFG.VUSBCTRL).
-     * It resets to disabled, and the PC3 input buffer is in the VUSB power
-     * domain - so PC3 cannot be read until VUSB is powered, even if USB
-     * itself is never used. Controlled by the "VUSB Power Source" menu;
-     * boards feeding external 3.3 V into VUSB leave this macro undefined. */
+     * It resets to disabled, and anything using the USB peripheral needs
+     * VUSB powered. Controlled by the "VUSB Power Source" menu; boards
+     * feeding external 3.3 V into VUSB leave this macro undefined. */
     SYSCFG.VUSBCTRL = SYSCFG_USBVREG_bm;
   #endif
   init_clock();

--- a/megaavr/cores/dxcore/wiring_analog.c
+++ b/megaavr/cores/dxcore/wiring_analog.c
@@ -721,13 +721,17 @@ inline __attribute__((always_inline)) void check_valid_resolution(uint8_t res) {
       // If high bit set, it's a channel, otherwise it's a digital pin so we look it up..
       pin = digitalPinToAnalogInput(pin);
     } else {
-      pin &= 0x3F;
+      /* The DU has a 7-bit MUXPOS with its internal channels at 0x40 (GND),
+       * 0x42 (TEMPSENSE) and 0x44 (VDDDIV10) - DS40002548B 32.4.12 - not at
+       * 0x30-0x33 like the parts around it. Masking with 0x3F turned
+       * ADC_GROUND / ADC_TEMPERATURE / ADC_VDDDIV10 into AIN0 / AIN2 / AIN4:
+       * it silently read three ordinary I/O pins and returned whatever they
+       * floated at, with no error. */
+      pin &= 0x7F;
     }
-    #if PROGMEM_SIZE < 8096
-      if (pin > 0x33) { // covers most ways a bad channel could come about
-    #else
-      if (pin > NUM_ANALOG_INPUTS && ((pin < 0x30) || (pin > 0x33))) {
-    #endif
+    /* Valid DU internal channels are exactly GND, TEMPSENSE and VDDDIV10;
+     * the reserved values in between must be rejected, not handed to the mux. */
+    if (pin > NUM_ANALOG_INPUTS && pin != 0x40 && pin != 0x42 && pin != 0x44) {
       return ADC_ERROR_BAD_PIN_OR_CHANNEL;
     }
     if (!(ADC0.CTRLA & 0x01)) return ADC_ERROR_DISABLED;
@@ -836,17 +840,13 @@ inline __attribute__((always_inline)) void check_valid_resolution(uint8_t res) {
       // If high bit set, it's a channel, otherwise it's a digital pin so we look it up..
       pin = digitalPinToAnalogInput(pin);
     } else {
-      pin &= 0x3F;
+      pin &= 0x7F;   /* see analogRead() above - DU internal channels live at 0x40/0x42/0x44 */
     }
-    #if PROGMEM_SIZE < 8096
-      if (pin > 0x33)  // covers most ways a bad channel could come about
-    #else
-      if (pin > NUM_ANALOG_INPUTS && ((pin < 0x30) || (pin > 0x33)))
-    #endif
+    if (pin > NUM_ANALOG_INPUTS && pin != 0x40 && pin != 0x42 && pin != 0x44)
     {
       return ADC_ENH_ERROR_BAD_PIN_OR_CHANNEL;
     }
-    pin &= 0x3F;
+    pin &= 0x7F;
 
     if (ADC0.COMMAND & ADC_START_gm) return ADC_ENH_ERROR_BUSY;
 
@@ -920,9 +920,16 @@ inline __attribute__((always_inline)) void check_valid_resolution(uint8_t res) {
       }
       uint8_t prescale = 0;
       for (uint8_t i = 0; i < 16; i++) {
-        int16_t clkadc = pgm_read_byte_near(&adc_prescale_to_clkadc[i]);
+        /* The table is int16_t in PROGMEM. It was read with pgm_read_byte_near()
+         * (low byte only) here, and with plain array indexing below and in the
+         * return - which dereferences the code-space address in the data space.
+         * The result was a garbage clock speed (e.g. -9227 kHz on a 24 MHz
+         * part where the answer is 2000) and a wrong prescaler whenever a
+         * frequency was requested. The EA/EB branch of this same function
+         * already reads the table correctly. */
+        int16_t clkadc = pgm_read_word_near(&adc_prescale_to_clkadc[i]);
         prescale = i;
-        if ((frequency >= clkadc) || (adc_prescale_to_clkadc[i + 1] < ((options & 0x01) ? 2 : 300))) {
+        if ((frequency >= clkadc) || ((int16_t)pgm_read_word_near(&adc_prescale_to_clkadc[i + 1]) < ((options & 0x01) ? 2 : 300))) {
           ADC0.CTRLB = prescale;
           break;
         }
@@ -931,7 +938,7 @@ inline __attribute__((always_inline)) void check_valid_resolution(uint8_t res) {
     if (frequency < 0) {
       return ADC_ERROR_INVALID_CLOCK;
     }
-    return adc_prescale_to_clkadc[ADC0.CTRLB];
+    return pgm_read_word_near(&adc_prescale_to_clkadc[ADC0.CTRLB & 0x0F]);
   }
 
 

--- a/megaavr/cores/dxcore/wiring_analog.c
+++ b/megaavr/cores/dxcore/wiring_analog.c
@@ -431,10 +431,10 @@ inline __attribute__((always_inline)) void check_valid_resolution(uint8_t res) {
 
     /* Wait for result ready */
     while (!(ADC0.INTFLAGS & ADC_RESRDY_bm));
-    // if it's 10 bit compatibility mode, have to rightshift twice.
+    // native resolution is ADC_NATIVE_RESOLUTION bits; shift down to the requested 10-bit if needed.
     if ((_analog_options & 0x0F) == 10) {
       int16_t temp = ADC0.RESULT;
-      temp >>= 2;
+      temp >>= (ADC_NATIVE_RESOLUTION - 10);
       return temp;
     }
     return ADC0.RESULT;
@@ -743,10 +743,10 @@ inline __attribute__((always_inline)) void check_valid_resolution(uint8_t res) {
 
     /* Wait for result ready */
     while (!(ADC0.INTFLAGS & ADC_RESRDY_bm));
-    // if it's 10 bit compatibility mode, have to rightshift twice.
+    // native resolution is ADC_NATIVE_RESOLUTION bits; shift down to the requested 10-bit if needed.
     if ((_analog_options & 0x0F) == 10) {
       int16_t temp = ADC0.RESULT;
-      temp >>= 2;
+      temp >>= (ADC_NATIVE_RESOLUTION - 10);
       return temp;
     }
     return ADC0.RESULT;

--- a/megaavr/cores/dxcore/wiring_analog.c
+++ b/megaavr/cores/dxcore/wiring_analog.c
@@ -418,7 +418,7 @@ inline __attribute__((always_inline)) void check_valid_resolution(uint8_t res) {
     #endif
       return ADC_ERROR_BAD_PIN_OR_CHANNEL;
     }
-    if (!ADC0.CTRLA & 0x01) return ADC_ERROR_DISABLED;
+    if (!(ADC0.CTRLA & 0x01)) return ADC_ERROR_DISABLED;
 
     if (ADC0.COMMAND & ADC_START_gm) return ADC_ERROR_BUSY;
     // gotta be careful here - don't want to shit ongoing conversion - unlikle classic AVRs
@@ -730,7 +730,7 @@ inline __attribute__((always_inline)) void check_valid_resolution(uint8_t res) {
     #endif
       return ADC_ERROR_BAD_PIN_OR_CHANNEL;
     }
-    if (!ADC0.CTRLA & 0x01) return ADC_ERROR_DISABLED;
+    if (!(ADC0.CTRLA & 0x01)) return ADC_ERROR_DISABLED;
 
     if (ADC0.COMMAND & ADC_START_gm) return ADC_ERROR_BUSY;
     // gotta be careful here - don't want to shit ongoing conversion - unlikle classic AVRs

--- a/megaavr/cores/dxcore/wiring_extra.cpp
+++ b/megaavr/cores/dxcore/wiring_extra.cpp
@@ -154,11 +154,21 @@ void pinConfigure(uint8_t digital_pin, uint16_t pin_config) {
   _pinconfigure(digital_pin, pin_config);
 }
 /* This may end up somewhere else (like in the library*/
-#if defined(PORTA_EVGENCTRL) //Ex-series only - this all may belong in the Event library anyway, but since the conditional is never met, this code is never used.
+#if defined(PORTA_EVGENCTRL) // Parts with the version 3 event system (EA/EB/DU-series). This all may belong in the Event library anyway.
+  /* Note: On the DU-series, bits 3 and 7 of PORTx.EVGENCTRLA are read-only zero (the EVGENnSEL
+   * fields are 3 bits wide, per DS40002548A section 18.5.10), so they CANNOT be used as "in use"
+   * flags and the automatic channel selection (chan = 255) is not available here - pass an
+   * explicit generator number, or better, use the Event library (assign_generator_pin()), which
+   * tracks usage in software instead. */
   uint8_t _setEventPin(uint8_t pin, uint8_t chan) {
     // Works the same was as
     uint8_t temp = digitalPinToPort(pin);
     if (temp != NOT_A_PIN && (chan == 255 || chan < 2)) { // (chan + 1) < 3 promoted to int, so chan = 255 could never take this path
+      #if defined(__AVR_DU__)
+        if (chan == 255) {
+          return 255; // see note above - no free/in-use flags exist on the DU-series.
+        }
+      #endif
       volatile uint8_t* p;
       p = (volatile uint8_t*) (uint16_t) (digitalPinToPortStruct(temp));
       p += 0x18; // now p pointing to evgenctrl.

--- a/megaavr/cores/dxcore/wiring_extra.cpp
+++ b/megaavr/cores/dxcore/wiring_extra.cpp
@@ -158,7 +158,7 @@ void pinConfigure(uint8_t digital_pin, uint16_t pin_config) {
   uint8_t _setEventPin(uint8_t pin, uint8_t chan) {
     // Works the same was as
     uint8_t temp = digitalPinToPort(pin);
-    if (temp != NOT_A_PIN && (chan + 1) < 3) {
+    if (temp != NOT_A_PIN && (chan == 255 || chan < 2)) { // (chan + 1) < 3 promoted to int, so chan = 255 could never take this path
       volatile uint8_t* p;
       p = (volatile uint8_t*) (uint16_t) (digitalPinToPortStruct(temp));
       p += 0x18; // now p pointing to evgenctrl.

--- a/megaavr/libraries/DxCore/examples/PWMTest/PWMTest.ino
+++ b/megaavr/libraries/DxCore/examples/PWMTest/PWMTest.ino
@@ -59,7 +59,9 @@
 // #define MYSERIALSWAP
 // Override below logic:
 #if !defined MYSERIALSWAP
-  #if defined(__AVR_DD__) && defined(_AVR_PINCOUNT) && _AVR_PINCOUNT == 14 && MYSERIAL == SERIAL
+  #if defined(__AVR_DU__)
+    #define MYSERIALSWAP 0
+  #elif defined(__AVR_DD__) && defined(_AVR_PINCOUNT) && _AVR_PINCOUNT == 14 && MYSERIAL == SERIAL
     #define MYSERIALSWAP 3 // Too likely I'll be using a clock, and it's a pain to have to wire up VDDIO2 to use serial.
   #elif MYSERIAL == SERIAL && ((CLOCK_SOURCE & 0x03) == 0)
     #define MYSERIALSWAP 1
@@ -236,6 +238,10 @@ void setup() {
 
 
   */
+#if defined(DAC0)
+  /* DAC turn-on/turn-off test - only on parts that have a DAC0 peripheral
+   * (AVR DA/DB/DD). Parts without a DAC (e.g. AVR DU) skip this entirely, so
+   * it is not counted as an attempt or a failure there. */
   analogWrite(PIN_PD6, 128);
   delay(100);
   uint8_t dacpassed = 0;
@@ -260,6 +266,7 @@ void setup() {
     MYSERIAL.print("DAC not turned off, voltage reads as ");
     MYSERIAL.println(dacread);
   }
+#endif
 }
 
 
@@ -322,7 +329,7 @@ void loop() {
 
     case 1: {
         //TCB
-        if (MILLIS_TIMER & 0x20) {
+        if ((MILLIS_TIMER & 0xF0) == 0x10) {  // TCB family is encoded 0x10-0x1F (TIMERB0..B7); was incorrectly 0x20 (TCF range)
           if ((MILLIS_TIMER & 0x07) == timernum) {
             MYSERIAL.print("Millis is using TCB");
             SkipCount++;

--- a/megaavr/libraries/Flash/src/Flash.cpp
+++ b/megaavr/libraries/Flash/src/Flash.cpp
@@ -405,20 +405,28 @@ uint8_t FlashClass::writeWords(const uint32_t address, const uint16_t* data, uin
 
 uint8_t FlashClass::writeBytes(const uint32_t address, const uint8_t* data, uint16_t length) {
   uint32_t tAddress = address;
-  uint8_t status;
-  if(address & 0x01) {
-    status = writeByte(tAddress++, *(data));
+  uint8_t status = FLASHWRITE_OK;
+  if (length == 0) {
+    return FLASHWRITE_0LENGTH;
+  }
+  if (tAddress & 0x01) {
+    // Unaligned start: write the leading byte, then continue word-aligned.
+    status = writeByte(tAddress++, *data++);
     if (status) return status;
     length--;
   }
-  if(length > 1) {
-    status = writeWords(tAddress, (uint16_t*) data, (length >> 1));
+  if (length > 1) {
+    // The bulk of the data, as whole words.
+    uint16_t words = length >> 1;
+    status = writeWords(tAddress, (uint16_t*) data, words);
     if (status) return status;
+    tAddress += ((uint32_t) words) << 1;
+    data     += words << 1;
+    length   -= words << 1;   // 0 or 1 byte left
   }
-  // there may be one more byte...
   if (length & 1) {
-    data += (length & 0xFFFE); // what we wrote with the word above...
-    status = writeByte(tAddress + length - 2, *data);
+    // And finally the trailing byte, if the length was odd.
+    status = writeByte(tAddress, *data);
   }
   return status;
 }

--- a/megaavr/variants/14pin-duseries/pins_arduino.h
+++ b/megaavr/variants/14pin-duseries/pins_arduino.h
@@ -72,7 +72,7 @@ Include guard and include basic libraries. We are normally including this inside
 
 
 #if !defined(LED_BUILTIN)
-  #define LED_BUILTIN                     (PIN_PD6) /* warning: gets overridden when using Serial1 on 14-pin parts, as that uses PD4. */
+  #define LED_BUILTIN                     (PIN_PD6) /* PD6 is USART1(ALT2) TxD on the DU; LED_BUILTIN is unavailable while Serial1 is in use. */
 #endif
 #ifdef CORE_ATTACH_OLD
   #define EXTERNAL_NUM_INTERRUPTS         (32)
@@ -152,30 +152,47 @@ Include guard and include basic libraries. We are normally including this inside
 
 // USART 0
 #define HWSERIAL0_MUX                   (0x00 /* PORTMUX_USART0_DEFAULT_gc */)
+#define HWSERIAL0_MUX_PINSWAP_1         (0x01 /* PORTMUX_USART0_ALT1_gc - PA4/PA5 absent on 14-pin; placeholder so the PINSWAP_3 row is built into _usart0_pins[] */)
+#define HWSERIAL0_MUX_PINSWAP_2         (0x02 /* PORTMUX_USART0_ALT2_gc - PA2/PA3 absent on 14-pin; placeholder */)
 #define HWSERIAL0_MUX_PINSWAP_3         (0x03 /* PORTMUX_USART0_ALT3_gc */)
 #define HWSERIAL0_MUX_PINSWAP_NONE      (0x05)
 #define PIN_HWSERIAL0_TX                (PIN_PA0)
 #define PIN_HWSERIAL0_RX                (PIN_PA1)
 #define PIN_HWSERIAL0_XCK               (NOT_A_PIN)
 #define PIN_HWSERIAL0_XDIR              (NOT_A_PIN)
+#define PIN_HWSERIAL0_TX_PINSWAP_1      (NOT_A_PIN)   /* ALT1 placeholder (PA4 absent on 14-pin) */
+#define PIN_HWSERIAL0_RX_PINSWAP_1      (NOT_A_PIN)
+#define PIN_HWSERIAL0_XCK_PINSWAP_1     (NOT_A_PIN)
+#define PIN_HWSERIAL0_XDIR_PINSWAP_1    (NOT_A_PIN)
+#define PIN_HWSERIAL0_TX_PINSWAP_2      (NOT_A_PIN)   /* ALT2 placeholder (PA2 absent on 14-pin) */
+#define PIN_HWSERIAL0_RX_PINSWAP_2      (NOT_A_PIN)
+#define PIN_HWSERIAL0_XCK_PINSWAP_2     (NOT_A_PIN)
+#define PIN_HWSERIAL0_XDIR_PINSWAP_2    (NOT_A_PIN)
 #define PIN_HWSERIAL0_TX_PINSWAP_3      (PIN_PD4)
 #define PIN_HWSERIAL0_RX_PINSWAP_3      (PIN_PD5)
 #define PIN_HWSERIAL0_XCK_PINSWAP_3     (PIN_PD6)
 #define PIN_HWSERIAL0_XDIR_PINSWAP_3    (PIN_PD7)
+#define HWSERIAL0_MUX_DEFAULT          (3)        /* DU default: USART0 ALT3 (PD4/PD5); row index of PINSWAP_3 */
 
 
 // USART1
 #define HWSERIAL1_MUX                   (0x00 /* PORTMUX_USART1_DEFAULT_gc */)
+#define HWSERIAL1_MUX_PINSWAP_1         (0x01 << 3 /* PORTMUX_USART1_ALT1_gc - absent on DU (PC4/PC5 not present); placeholder so the PINSWAP_2 row is built into _usart1_pins[] */)
 #define HWSERIAL1_MUX_PINSWAP_2         (0x02 << 3 /* PORTMUX_USART1_ALT2_gc */)
-#define HWSERIAL1_MUX_PINSWAP_NONE      (0x03 << 2 /* PORTMUX_USART1_NONE_gc */)
+#define HWSERIAL1_MUX_PINSWAP_NONE      (0x03 << 3 /* PORTMUX_USART1_NONE_gc */)
 #define PIN_HWSERIAL1_TX                (NOT_A_PIN)
 #define PIN_HWSERIAL1_RX                (NOT_A_PIN)
 #define PIN_HWSERIAL1_XCK               (NOT_A_PIN)
 #define PIN_HWSERIAL1_XDIR              (NOT_A_PIN)
+#define PIN_HWSERIAL1_TX_PINSWAP_1      (NOT_A_PIN)   /* ALT1 placeholder (absent on DU) */
+#define PIN_HWSERIAL1_RX_PINSWAP_1      (NOT_A_PIN)
+#define PIN_HWSERIAL1_XCK_PINSWAP_1     (NOT_A_PIN)
+#define PIN_HWSERIAL1_XDIR_PINSWAP_1    (NOT_A_PIN)
 #define PIN_HWSERIAL1_TX_PINSWAP_2      (PIN_PD6)
 #define PIN_HWSERIAL1_RX_PINSWAP_2      (PIN_PD7)
 #define PIN_HWSERIAL1_XCK_PINSWAP_2     (NOT_A_PIN)
 #define PIN_HWSERIAL1_XDIR_PINSWAP_2    (NOT_A_PIN)
+#define HWSERIAL1_MUX_DEFAULT          (2)        /* DU default: USART1 ALT2 (PD6/PD7); row index of PINSWAP_2 (USART1 has no usable DEFAULT position on DU) */
 
         /*##  #   #  ###  #     ###   ###      ####  ### #   #  ###
         #   # ##  # #   # #    #   # #         #   #  #  ##  # #
@@ -379,4 +396,5 @@ const uint8_t digital_pin_to_bit_mask[] = { // *INDENT-OFF*
   };
 
 #endif
+
 #endif

--- a/megaavr/variants/20pin-duseries/pins_arduino.h
+++ b/megaavr/variants/20pin-duseries/pins_arduino.h
@@ -151,6 +151,7 @@ Include guard and include basic libraries. We are normally including this inside
 #define HWSERIAL0_MUX_PINSWAP_2         (0x02 /* PORTMUX_USART0_ALT2_gc */)
 #define HWSERIAL0_MUX_PINSWAP_3         (0x03 /* PORTMUX_USART0_ALT3_gc */)
 #define HWSERIAL0_MUX_PINSWAP_NONE      (0x05)
+#define HWSERIAL0_MUX_DEFAULT          (3)        /* DU default: USART0 ALT3 (PD4/PD5); row index of PINSWAP_3 */
 #define PIN_HWSERIAL0_TX                (PIN_PA0)
 #define PIN_HWSERIAL0_RX                (PIN_PA1)
 #define PIN_HWSERIAL0_XCK               (PIN_PA2)
@@ -170,16 +171,22 @@ Include guard and include basic libraries. We are normally including this inside
 
 // USART1
 #define HWSERIAL1_MUX                   (0x00 /* PORTMUX_USART1_DEFAULT_gc */)
+#define HWSERIAL1_MUX_PINSWAP_1         (0x01 << 3 /* PORTMUX_USART1_ALT1_gc - absent on DU (PC4/PC5 not present); placeholder so the PINSWAP_2 row is built into _usart1_pins[] */)
 #define HWSERIAL1_MUX_PINSWAP_2         (0x02 << 3 /* PORTMUX_USART1_ALT2_gc */)
 #define HWSERIAL1_MUX_PINSWAP_NONE      (0x03 << 3)
 #define PIN_HWSERIAL1_TX                (NOT_A_PIN)
 #define PIN_HWSERIAL1_RX                (NOT_A_PIN)
 #define PIN_HWSERIAL1_XCK               (NOT_A_PIN)
 #define PIN_HWSERIAL1_XDIR              (NOT_A_PIN)
+#define PIN_HWSERIAL1_TX_PINSWAP_1      (NOT_A_PIN)   /* ALT1 placeholder (absent on DU) */
+#define PIN_HWSERIAL1_RX_PINSWAP_1      (NOT_A_PIN)
+#define PIN_HWSERIAL1_XCK_PINSWAP_1     (NOT_A_PIN)
+#define PIN_HWSERIAL1_XDIR_PINSWAP_1    (NOT_A_PIN)
 #define PIN_HWSERIAL1_TX_PINSWAP_2      (PIN_PD6)
 #define PIN_HWSERIAL1_RX_PINSWAP_2      (PIN_PD7)
 #define PIN_HWSERIAL1_XCK_PINSWAP_2     (NOT_A_PIN)
 #define PIN_HWSERIAL1_XDIR_PINSWAP_2    (NOT_A_PIN)
+#define HWSERIAL1_MUX_DEFAULT          (2)        /* DU default: USART1 ALT2 (PD6/PD7); row index of PINSWAP_2 (USART1 has no usable DEFAULT position on DU) */
 
         /*##  #   #  ###  #     ###   ###      ####  ### #   #  ###
         #   # ##  # #   # #    #   # #         #   #  #  ##  # #
@@ -395,4 +402,5 @@ static const uint8_t A31 = PIN_A31;
   };
 
   #endif
+
 #endif

--- a/megaavr/variants/28pin-duseries/pins_arduino.h
+++ b/megaavr/variants/28pin-duseries/pins_arduino.h
@@ -166,6 +166,7 @@ Include guard and include basic libraries. We are normally including this inside
 #define HWSERIAL0_MUX_PINSWAP_2         (0x02 /* PORTMUX_USART0_ALT2_gc */)
 #define HWSERIAL0_MUX_PINSWAP_3         (0x03 /* PORTMUX_USART0_ALT3_gc */)
 #define HWSERIAL0_MUX_PINSWAP_NONE      (0x05)
+#define HWSERIAL0_MUX_DEFAULT          (3)        /* DU default: USART0 ALT3 (PD4/PD5); row index of PINSWAP_3 */
 #define PIN_HWSERIAL0_TX                (PIN_PA0)
 #define PIN_HWSERIAL0_RX                (PIN_PA1)
 #define PIN_HWSERIAL0_XCK               (PIN_PA2)
@@ -185,16 +186,22 @@ Include guard and include basic libraries. We are normally including this inside
 
 // USART1
 #define HWSERIAL1_MUX                   (0x00 /* PORTMUX_USART1_DEFAULT_gc */)
+#define HWSERIAL1_MUX_PINSWAP_1         (0x01 << 3 /* PORTMUX_USART1_ALT1_gc - absent on DU (PC4/PC5 not present); placeholder so the PINSWAP_2 row is built into _usart1_pins[] */)
 #define HWSERIAL1_MUX_PINSWAP_2         (0x02 << 3 /* PORTMUX_USART1_ALT2_gc */)
 #define HWSERIAL1_MUX_PINSWAP_NONE      (0x03 << 3)
 #define PIN_HWSERIAL1_TX                (NOT_A_PIN)
 #define PIN_HWSERIAL1_RX                (NOT_A_PIN)
 #define PIN_HWSERIAL1_XCK               (NOT_A_PIN)
 #define PIN_HWSERIAL1_XDIR              (NOT_A_PIN)
+#define PIN_HWSERIAL1_TX_PINSWAP_1      (NOT_A_PIN)   /* ALT1 placeholder (absent on DU) */
+#define PIN_HWSERIAL1_RX_PINSWAP_1      (NOT_A_PIN)
+#define PIN_HWSERIAL1_XCK_PINSWAP_1     (NOT_A_PIN)
+#define PIN_HWSERIAL1_XDIR_PINSWAP_1    (NOT_A_PIN)
 #define PIN_HWSERIAL1_TX_PINSWAP_2      (PIN_PD6)
 #define PIN_HWSERIAL1_RX_PINSWAP_2      (PIN_PD7)
 #define PIN_HWSERIAL1_XCK_PINSWAP_2     (NOT_A_PIN)
 #define PIN_HWSERIAL1_XDIR_PINSWAP_2    (NOT_A_PIN)
+#define HWSERIAL1_MUX_DEFAULT          (2)        /* DU default: USART1 ALT2 (PD6/PD7); row index of PINSWAP_2 (USART1 has no usable DEFAULT position on DU) */
 
         /*##  #   #  ###  #     ###   ###      ####  ### #   #  ###
         #   # ##  # #   # #    #   # #         #   #  #  ##  # #
@@ -443,4 +450,5 @@ static const uint8_t A31 = PIN_A31;
   };
 
 #endif
+
 #endif

--- a/megaavr/variants/32pin-duseries/pins_arduino.h
+++ b/megaavr/variants/32pin-duseries/pins_arduino.h
@@ -166,6 +166,7 @@ Include guard and include basic libraries. We are normally including this inside
 #define HWSERIAL0_MUX_PINSWAP_2         (0x02 /* PORTMUX_USART0_ALT2_gc */)
 #define HWSERIAL0_MUX_PINSWAP_3         (0x03 /* PORTMUX_USART0_ALT3_gc */)
 #define HWSERIAL0_MUX_PINSWAP_NONE      (0x05)
+#define HWSERIAL0_MUX_DEFAULT          (3)        /* DU default: USART0 ALT3 (PD4/PD5); row index of PINSWAP_3 */
 #define PIN_HWSERIAL0_TX                (PIN_PA0)
 #define PIN_HWSERIAL0_RX                (PIN_PA1)
 #define PIN_HWSERIAL0_XCK               (PIN_PA2)
@@ -185,16 +186,22 @@ Include guard and include basic libraries. We are normally including this inside
 
 // USART1
 #define HWSERIAL1_MUX                   (0x00 /* PORTMUX_USART1_DEFAULT_gc */)
+#define HWSERIAL1_MUX_PINSWAP_1         (0x01 << 3 /* PORTMUX_USART1_ALT1_gc - absent on DU (PC4/PC5 not present); placeholder so the PINSWAP_2 row is built into _usart1_pins[] */)
 #define HWSERIAL1_MUX_PINSWAP_2         (0x02 << 3 /* PORTMUX_USART1_ALT2_gc */)
 #define HWSERIAL1_MUX_PINSWAP_NONE      (0x03 << 3)
 #define PIN_HWSERIAL1_TX                (NOT_A_PIN)
 #define PIN_HWSERIAL1_RX                (NOT_A_PIN)
 #define PIN_HWSERIAL1_XCK               (NOT_A_PIN)
 #define PIN_HWSERIAL1_XDIR              (NOT_A_PIN)
+#define PIN_HWSERIAL1_TX_PINSWAP_1      (NOT_A_PIN)   /* ALT1 placeholder (absent on DU) */
+#define PIN_HWSERIAL1_RX_PINSWAP_1      (NOT_A_PIN)
+#define PIN_HWSERIAL1_XCK_PINSWAP_1     (NOT_A_PIN)
+#define PIN_HWSERIAL1_XDIR_PINSWAP_1    (NOT_A_PIN)
 #define PIN_HWSERIAL1_TX_PINSWAP_2      (PIN_PD6)
 #define PIN_HWSERIAL1_RX_PINSWAP_2      (PIN_PD7)
 #define PIN_HWSERIAL1_XCK_PINSWAP_2     (NOT_A_PIN)
 #define PIN_HWSERIAL1_XDIR_PINSWAP_2    (NOT_A_PIN)
+#define HWSERIAL1_MUX_DEFAULT          (2)        /* DU default: USART1 ALT2 (PD6/PD7); row index of PINSWAP_2 (USART1 has no usable DEFAULT position on DU) */
 
         /*##  #   #  ###  #     ###   ###      ####  ### #   #  ###
         #   # ##  # #   # #    #   # #         #   #  #  ##  # #
@@ -448,4 +455,5 @@ static const uint8_t A31 = PIN_A31;
   };
 
 #endif
+
 #endif


### PR DESCRIPTION
Fixes for the generic `avrdu` (no-bootloader) board so a DU part works out of the box over UPDI.
This is based on #650 (first three commits) and, like that PR, isolates the changes from #637.

**boards.txt**
- `build.highestcb`: B2 → B1. No DU part has a TCB2 (DS40002548A).
- "Burn Bootloader" never wrote SYSCFG0: `{bootloader.resetpinbits}` / `{bootloader.eesavebit}` were undefined
  and no `avrdudefuse5` template existed. Added, plus the eesave menu (parity with avrda/db/dd).
- New "VUSB Power Source" menu: SYSCFG.VUSBCTRL resets to regulator-off, and anything using the USB peripheral needs VUSB powered.
  init() enables the internal regulator when selected (the common case); boards feeding external 3.3 V into VUSB pick the other option.

**Core / example**
- analogRead 10-bit path assumed a 12-bit native ADC; the DU is natively 10-bit, so readings were squashed to 8 bits.
  Now shifts by (ADC_NATIVE_RESOLUTION - 10); both ADC paths fixed, 12-bit parts unchanged.
- DU EVGENCTRL bits 3/7 are read-only zero, so auto channel selection can't work there; returns 255, documented in place.
- DU variants define usable default mux positions: Serial0 = PD4/PD5,
  Serial1 = PD6/PD7 (USART1's only position on the DU).
  No core change needed - UART_swap.h already honours variant overrides.
- PWMTest example runs on DU parts.
- ADC: the DU has a 7-bit MUXPOS with its internal channels at 0x40/0x42/0x44,
  not the 0x30-0x33 of the neighbouring parts,
  so a 0x3F mask and the range check together broke ADC_GROUND/TEMPERATURE/VDDDIV10.
  Also, analogClockSpeed() read its int16_t PROGMEM table a byte at a time and returned garbage (-9227 kHz where the answer is 2000).
  Both verified on an AVR64DU32.

**Testing** (AVR64DU32 Curiosity Nano, nEDBG/UPDI)
- Blink builds for AVR128DA48 (regression) and AVR64DU32.
- Burn Bootloader now writes fuse 5 (SYSCFG0 = 0xD9, verified on hardware).
  Note: the full fuse write also needs #633's OSCCFG / SYSCFG1 fixes confirmed it stops at fuse2 without them,
  and completes with them applied locally.
  This PR doesn't duplicate #633.
- Serial1 works on PD6/PD7 with no swap() call (echo test via the debugger's CDC bridge).

The `avrduusb` board, USB stack, and CDC bootloader stay in new next PR.