### PR TITLE
analogWrite: set the pin as an output for the 0 and 255 endpoints

### DIFF
--- a/megaavr/cores/dxcore/wiring_pwm.c
+++ b/megaavr/cores/dxcore/wiring_pwm.c
@@ -451,7 +451,25 @@ void analogWrite(uint8_t pin, int val) {
   uint8_t bit_mask = digitalPinToBitMask(pin);
   if (bit_mask == NOT_A_PIN) return; //this catches any run-time determined pin that isn't a pin.
   if ((val == 0 || val == 255)) {
-    digitalWrite(pin,val ? HIGH : LOW);
+    /* The classic Arduino AVR core calls pinMode(pin, OUTPUT) *before* this
+     * branch ("make sure the pin is in output mode ... which doesn't require
+     * a pinMode call for the analog output pins" - ArduinoCore-avr,
+     * wiring_analog.c). Previously this returned without ever setting the
+     * direction, so on a pin that had not already been made an output,
+     * analogWrite(pin, 0) left it Hi-Z and analogWrite(pin, 255) only
+     * enabled the pull-up instead of driving the pin high. The normal PWM
+     * path below always ends in _setOutput(), so only these two endpoint
+     * values were affected - which is exactly where a sketch is most likely
+     * to skip pinMode() (fades that start at 0, on/off via analogWrite).
+     * digitalWrite() first (it sets OUT and turns PWM off), then the
+     * direction, so the pin never briefly drives a stale level. Leaving
+     * PULLUPEN set by digitalWrite()'s input-pin emulation is harmless and
+     * matches classic AVR semantics: the pull-up is disconnected while the
+     * pin is configured as an output (DU datasheet DS40002548B 18.3.2.3,
+     * and equivalents on the other parts). */
+    uint8_t portnum = digitalPinToPort(pin);
+    digitalWrite(pin, val ? HIGH : LOW);
+    _setOutput(portnum, bit_mask);
     return;
   }
   uint8_t portnum  = digitalPinToPort(pin);

--- a/megaavr/cores/dxcore/wiring_pwm.c
+++ b/megaavr/cores/dxcore/wiring_pwm.c
@@ -451,22 +451,6 @@ void analogWrite(uint8_t pin, int val) {
   uint8_t bit_mask = digitalPinToBitMask(pin);
   if (bit_mask == NOT_A_PIN) return; //this catches any run-time determined pin that isn't a pin.
   if ((val == 0 || val == 255)) {
-    /* The classic Arduino AVR core calls pinMode(pin, OUTPUT) *before* this
-     * branch ("make sure the pin is in output mode ... which doesn't require
-     * a pinMode call for the analog output pins" - ArduinoCore-avr,
-     * wiring_analog.c). Previously this returned without ever setting the
-     * direction, so on a pin that had not already been made an output,
-     * analogWrite(pin, 0) left it Hi-Z and analogWrite(pin, 255) only
-     * enabled the pull-up instead of driving the pin high. The normal PWM
-     * path below always ends in _setOutput(), so only these two endpoint
-     * values were affected - which is exactly where a sketch is most likely
-     * to skip pinMode() (fades that start at 0, on/off via analogWrite).
-     * digitalWrite() first (it sets OUT and turns PWM off), then the
-     * direction, so the pin never briefly drives a stale level. Leaving
-     * PULLUPEN set by digitalWrite()'s input-pin emulation is harmless and
-     * matches classic AVR semantics: the pull-up is disconnected while the
-     * pin is configured as an output (DU datasheet DS40002548B 18.3.2.3,
-     * and equivalents on the other parts). */
     uint8_t portnum = digitalPinToPort(pin);
     digitalWrite(pin, val ? HIGH : LOW);
     _setOutput(portnum, bit_mask);


### PR DESCRIPTION
The val==0 / val==255 branch returned without setting the pin direction.
The classic AVR core calls pinMode(pin, OUTPUT) in analogWrite.
(the API docs promise analog output pins need no pinMode call)

So on a pin not already an output:

    analogWrite(pin, 0)   -> Hi-Z instead of driven low
    analogWrite(pin, 255) -> pull-up only instead of driven high

Only these two values are affected (the normal PWM path ends in _setOutput()).

Additional Information:
megaTinyCore's analogWrite has the same pattern.